### PR TITLE
Feed javacpp.jar path to temp file deleter

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -569,11 +570,13 @@ public class Loader {
                         LinkedList<String> command = new LinkedList<String>();
                         command.add(System.getProperty("java.home") + "/bin/java");
                         command.add("-classpath");
-                        command.add(System.getProperty("java.class.path"));
+                        command.add((new File(Loader.class.getProtectionDomain().getCodeSource().getLocation().toURI())).toString());
                         command.add(Loader.class.getName());
                         command.add(tempDir.getAbsolutePath());
                         new ProcessBuilder(command).start();
                     } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    } catch (URISyntaxException e) {
                         throw new RuntimeException(e);
                     }
                 }


### PR DESCRIPTION
Get OS-localized file path to jar file enclosing Loader class, and feed this path to the temp file deleter on Windows instead of java.class.path. If the java program is launched through a dedicated classpath loader, java.class.path may not contain the javacpp jar. By locating the correct jar, this circumstance should be avoided.