### PR TITLE
squid:CommentedOutCodeLine - Sections of code should not be "commented out"

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -60,18 +60,7 @@ import org.bytedeco.javacpp.tools.Logger;
  */
 public class Pointer implements AutoCloseable {
     /** Default constructor that does nothing. */
-    public Pointer() {
-        // Make sure our top enclosing class is initialized and the
-        // associated native library loaded. This code is actually quite efficient,
-        // but it still does not cover all corner cases...
-//        Class cls = getClass();
-//        String className = cls.getName();
-//        int topIndex = className.indexOf('$');
-//        if (topIndex > 0 && Loader.loadedLibraries.
-//                get(className.substring(0, topIndex)) == null) {
-//            Loader.load(cls);
-//        }
-    }
+    public Pointer() {}
     /**
      * Copies the address, position, limit, and capacity of another Pointer.
      * Also keeps a reference to it to prevent its memory from getting deallocated.
@@ -214,8 +203,6 @@ public class Pointer implements AutoCloseable {
 
         @Override public void deallocate() {
             if (ownerAddress != 0 && deallocatorAddress != 0) {
-//                System.out.println("deallocating 0x" + Long.toHexString(ownerAddress) +
-//                        " 0x" + Long.toHexString(deallocatorAddress));
                 deallocate(ownerAddress, deallocatorAddress);
                 ownerAddress = deallocatorAddress = 0;
             }

--- a/src/main/java/org/bytedeco/javacpp/tools/Builder.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Builder.java
@@ -426,8 +426,6 @@ public class Builder {
             }
             fis.close();
             jos.closeEntry();
-//            f.delete();
-//            f.getParentFile().delete();
         }
         jos.close();
     }

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -1322,9 +1322,6 @@ public class Generator implements Closeable {
                         typeName[0] = functionClassName(methodInfo.returnType) + "*";
                         typeName[1] = "";
                         valueTypeName = valueTypeName(typeName);
-//                    } else if (virtualFunctions.containsKey(methodInfo.returnType)) {
-//                        String subType = "JavaCPP_" + mangle(valueTypeName);
-//                        valueTypeName = subType;
                     }
                     if (returnBy instanceof ByVal) {
                         returnPrefix += (noException(methodInfo.returnType, methodInfo.method) ?
@@ -1686,10 +1683,6 @@ public class Generator implements Closeable {
                     } else {
                         out.println(indent + "        env->SetLongField(rarg, JavaCPP_addressFID, ptr_to_jlong(rptr));");
                     }
-//                    if (returnBy instanceof ByVal && virtualFunctions.containsKey(methodInfo.returnType)) {
-//                        String subType = "JavaCPP_" + mangle(valueTypeName);
-//                        out.println(indent + "        ((" + subType + "*))rptr->obj = env->NewWeakGlobalRef(rarg);");
-//                    }
                     out.println(indent + "    }");
                     out.println(indent + "}");
                 } else if (methodInfo.returnType == String.class) {

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -804,7 +804,6 @@ public class Parser {
                     dimCast += "[" + dims[i] + "]";
                 }
             }
-            //dcl.indices = 0;
             cast += dimCast.length() > 0 ? "(*)" + dimCast : "*";
         }
         if (pointerAsArray && dcl.indirections > (type.anonymous ? 0 : 1)) {
@@ -1572,7 +1571,6 @@ public class Parser {
             if (info != null && info.javaText != null) {
                 if (first) {
                     decl.text = info.javaText;
-//                    decl.declarator = null;
                 } else {
                     break;
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:CommentedOutCodeLine - Sections of code should not be "commented out".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
Please let me know if you have any questions.
George Kankava