### PR TITLE
squid:S00108 - Nested blocks of code should not be left empty

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -150,12 +150,16 @@ public class Loader {
             } finally {
                 try {
                     is2.close();
-                } catch (IOException ex) { }
+                } catch (IOException ex) {
+                    logger.error("Unable to close resource : " + ex.getMessage());
+                }
             }
         } finally {
             try {
                 is.close();
-            } catch (IOException ex) { }
+            } catch (IOException ex) {
+                logger.error("Unable to close resource : " + ex.getMessage());
+            }
         }
         return p;
     }
@@ -235,7 +239,9 @@ public class Loader {
                     return super.getClassContext();
                 }
             }.getClassContext();
-        } catch (NoSuchMethodError e) { }
+        } catch (NoSuchMethodError e) {
+            logger.error("No definition of this method : " + e.getMessage());
+        }
         if (classContext != null) {
             for (int j = 0; j < classContext.length; j++) {
                 if (classContext[j] == Loader.class) {
@@ -251,7 +257,9 @@ public class Loader {
                         return Class.forName(classNames[i+j].getClassName());
                     }
                 }
-            } catch (ClassNotFoundException e) { }
+            } catch (ClassNotFoundException e) {
+                logger.error("No definition for the class found : " + e.getMessage());
+            }
         }
         return null;
     }

--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -457,7 +457,9 @@ public class Pointer implements AutoCloseable {
             if (c != Pointer.class) {
                 offset = Loader.offsetof(c, member);
             }
-        } catch (NullPointerException e) { }
+        } catch (NullPointerException e) {
+            return offset;
+        }
         return offset;
     }
 

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -2687,18 +2687,14 @@ public class Parser {
         for (Class c : allInherited) {
             try {
                 ((InfoMapper)c.newInstance()).map(infoMap);
-            } catch (ClassCastException e) {
-            } catch (InstantiationException e) {
-            } catch (IllegalAccessException e) {
+            } catch (ClassCastException |  InstantiationException | IllegalAccessException e) {
                 // fail silently as if the interface wasn't implemented
             }
         }
         leafInfoMap = new InfoMap();
         try {
             ((InfoMapper)cls.newInstance()).map(leafInfoMap);
-        } catch (ClassCastException e) {
-        } catch (InstantiationException e) {
-        } catch (IllegalAccessException e) {
+        } catch (ClassCastException |  InstantiationException | IllegalAccessException e) {
             // fail silently as if the interface wasn't implemented
         }
         infoMap.putAll(leafInfoMap);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00108 - Nested blocks of code should not be left empty.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00108
Please let me know if you have any questions.
George Kankava