### PR TITLE
add definition of linux-armhf arch based on sun.arch.abi property

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -66,6 +66,7 @@ public class Loader {
         String jvmName = System.getProperty("java.vm.name", "").toLowerCase();
         String osName  = System.getProperty("os.name", "").toLowerCase();
         String osArch  = System.getProperty("os.arch", "").toLowerCase();
+        String abiType = System.getProperty("sun.arch.abi", "").toLowerCase();
         if (jvmName.startsWith("dalvik") && osName.startsWith("linux")) {
             osName = "android";
         } else if (jvmName.startsWith("robovm") && osName.startsWith("darwin")) {
@@ -85,7 +86,9 @@ public class Loader {
             osArch = "x86_64";
         } else if (osArch.startsWith("aarch64") || osArch.startsWith("armv8") || osArch.startsWith("arm64")) {
             osArch = "arm64";
-        } else if (osArch.startsWith("arm")) {
+        } else if ((osArch.startsWith("arm")) && abiType.equals("gnueabihf")) {
+            osArch = "armhf";
+	} else if (osArch.startsWith("arm")) {
             osArch = "arm";
         }
         PLATFORM = osName + "-" + osArch;

--- a/src/main/resources/org/bytedeco/javacpp/properties/linux-armhf.properties
+++ b/src/main/resources/org/bytedeco/javacpp/properties/linux-armhf.properties
@@ -1,0 +1,22 @@
+platform=linux-armhf
+platform.path.separator=:
+platform.source.suffix=.cpp
+platform.includepath.prefix=-I
+platform.includepath=
+platform.compiler=g++
+platform.compiler.cpp11=-std=c++11
+platform.compiler.default=-march=armv7
+platform.compiler.fastfpu=-march=armv7-a -mfpu=neon -ffast-math
+platform.compiler.nodeprecated=-Wno-deprecated-declarations
+platform.compiler.output=-Wl,-rpath,$ORIGIN/ -Wall -O3 -fPIC -shared -s -o\u0020
+platform.linkpath.prefix=-L
+platform.linkpath.prefix2=-Wl,-rpath,
+platform.linkpath=
+platform.link.prefix=-l
+platform.link.suffix=
+platform.link=
+platform.framework.prefix=-F
+platform.framework.suffix=
+platform.framework=
+platform.library.prefix=lib
+platform.library.suffix=.so


### PR DESCRIPTION
Trying to add a clean addition that won't break anyone already using linux-arm for other arm types, but will allow specification of flags aimed at the pi2, so platform specific linux-armhf jars could be cross-compiled for that target

Update for cppbuild.sh in javacpp-presets would build these dependencies, and then the Loader class select to use them on the target