### PR TITLE
Remove 'throws Exception' from Pointer::close

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -402,7 +402,7 @@ public class Pointer implements AutoCloseable {
     }
 
     /** Calls {@code deallocate()}. */
-    @Override public void close() throws Exception {
+    @Override public void close() {
         deallocate();
     }
 


### PR DESCRIPTION
Pointer throws a RuntimeException on close.  Removing the throws
allows the user's try-with-resource blocks not require a catch(Exception)