### PR TITLE
Comment with first dimension of multidimensional array inside @Cast

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -825,7 +825,19 @@ public class Parser {
                     dimCast += "[" + dims[i] + "]";
                 }
             }
-            cast += dimCast.length() > 0 ? "(*)" + dimCast : "*";
+            
+            if (!dimCast.isEmpty()) {
+                if (dims[0] != -1) {
+                    // Annotate with the first dimension's value
+                    cast += "(*\"+/*[" + dims[0] + "]*/\")";
+                } else {
+                    // Unknown size
+                    cast += "(*)";
+                }
+                cast += dimCast;
+            } else {
+                cast += "*";
+            }
         }
         if (pointerAsArray && dcl.indirections > (type.anonymous ? 0 : 1)) {
             // treat second indirection as an array, unless anonymous

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -829,7 +829,7 @@ public class Parser {
             if (!dimCast.isEmpty()) {
                 if (dims[0] != -1) {
                     // Annotate with the first dimension's value
-                    cast += "(*\"+/*[" + dims[0] + "]*/\")";
+                    cast += "(* /*[" + dims[0] + "]*/ )";
                 } else {
                     // Unknown size
                     cast += "(*)";


### PR DESCRIPTION
It's handy to see all dimensions of the input array even thought the cast needs to be `(*)`.

This will generate code such as `@Cast("const double(*"+/*[4]*/")[2]") DoubleBuffer quad`