### PR TITLE
escape empty strings for nullValue

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -1466,7 +1466,8 @@ public class Parser {
                 }
                 if (n >= 0) {
                     s = s.substring(0, n + 6) + "(nullValue = \""
-                            + defaultValue.replaceAll("\n(\\s*)", "\"\n$1 + \"") + "\")" + s.substring(n + 6);
+                            + defaultValue.replaceAll("\n(\\s*)", "\"\n$1 + \"")
+                                          .replaceAll("\"", "\\\\\"") + "\")" + s.substring(n + 6);
                 }
                 dcl.type.annotations = s;
             }


### PR DESCRIPTION
Cleaned up version of previous PR. This will fix some problems with nullValue having a value of  """", which is invalid Java