### PR TITLE
update maven plugins for openjdk9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>
@@ -190,7 +190,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-source</id>
@@ -202,7 +202,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>2.10.4</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
Tested with openjdk9, seemed to be some known issues with earlier maven plugins causing crashed. Looks like builds OK with newer versions