### PR TITLE
Fix generate of @Const on function

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/annotation/Const.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Const.java
@@ -5,18 +5,21 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.bytedeco.javacpp.FunctionPointer;
+import org.bytedeco.javacpp.tools.Generator;
 
 /**
- * A shortcut annotation to {@link Cast} that simply adds {@code const} to the parameter type, function or class.
+ * A shortcut annotation to {@link Cast} that simply adds {@code const} to the parameter type, function, or class.
  *
  * <p><ul>
- * <li>For parameter type, the first one is for a value like {@code const char*} and the second for a pointer like {@code char const *}.
- * <li>For function, the first and third one are used. The first is applied to the return value/pointer.
- * The third one determines whether the function is {@code const} or not. For compatible problem, we keep the third value empty.
- * <li>For class, only the first one is used, if it is {@code true}, it means the functions are all {@code const}
+ * <li>For a parameter type, the first element is for a value like {@code const char*} and the second for a pointer like {@code char const *}.
+ * <li>For a function, the first, second, and third ones are used. The first two are applied to the return value/pointer.
+ *     The third one determines whether the function is {@code const} or not. For backward compatibility, we keep the third element empty.
+ * <li>For a class, only the first one is used, and if it is {@code true}, it means all the functions are {@code const}.
+ *     Can also be declared on a {@link FunctionPointer} in the case of {@code const} functions.
  * </ul></p>
  *
- * @see {@link org.bytedeco.javacpp.tools.Generator}
+ * @see Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Const.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Const.java
@@ -5,14 +5,18 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.FunctionPointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
- * A shortcut annotation to {@link Cast} that simply adds {@code const} to the parameter type.
- * Can also be declared on a {@link FunctionPointer} in the case of {@code const} functions.
+ * A shortcut annotation to {@link Cast} that simply adds {@code const} to the parameter type, function or class.
  *
- * @see Generator
+ * <p><ul>
+ * <li>For parameter type, the first one is for a value like {@code const char*} and the second for a pointer like {@code char const *}.
+ * <li>For function, the first and third one are used. The first is applied to the return value/pointer.
+ * The third one determines whether the function is {@code const} or not. For compatible problem, we keep the third value empty.
+ * <li>For class, only the first one is used, if it is {@code true}, it means the functions are all {@code const}
+ * </ul></p>
+ *
+ * @see {@link org.bytedeco.javacpp.tools.Generator}
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -22,6 +22,29 @@
 
 package org.bytedeco.javacpp.tools;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import org.bytedeco.javacpp.BoolPointer;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.CLongPointer;
@@ -63,30 +86,6 @@ import org.bytedeco.javacpp.annotation.Raw;
 import org.bytedeco.javacpp.annotation.ValueGetter;
 import org.bytedeco.javacpp.annotation.ValueSetter;
 import org.bytedeco.javacpp.annotation.Virtual;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.Writer;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.nio.Buffer;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
-import java.nio.LongBuffer;
-import java.nio.ShortBuffer;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
 
 /**
  * The Generator is where all the C++ source code that we need gets generated.

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -3272,12 +3272,16 @@ public class Generator {
                 }
                 typeName = prefix.length() > 0 ? new String[] { prefix, suffix } : null;
             } else if (a instanceof Const) {
+                boolean[] b = ((Const)a).value();
+                if ((b.length == 1 && !b[0]) || (b.length > 1 && !b[0] && !b[1])) {
+                    // not interested in const members
+                    continue;
+                }
                 if (warning = typeName != null) {
                     // prioritize @Cast
                     continue;
                 }
                 typeName = cppTypeName(type);
-                boolean[] b = ((Const)a).value();
                 if (b.length > 1 && b[1] && !typeName[0].endsWith(" const *")) {
                     typeName[0] = valueTypeName(typeName) + " const *";
                 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -22,9 +22,6 @@
 
 package org.bytedeco.javacpp.tools;
 
-import org.bytedeco.javacpp.ClassProperties;
-import org.bytedeco.javacpp.Loader;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -37,6 +34,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.bytedeco.javacpp.ClassProperties;
+import org.bytedeco.javacpp.Loader;
 
 /**
  * The Parser, just like the Generator, is a mess that is not meant to support the

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -1934,7 +1934,8 @@ public class Parser {
                 tokens.next();
             }
 
-            if (decl.constMember) {
+            // add @Const annotation only for const virtual functions
+            if (decl.constMember && type.virtual && context.virtualize) {
                 if (type.annotations.contains("@Const")) {
                     type.annotations = incorporateConstAnnotation(type.annotations, 2, true);
                 } else {

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -22,6 +22,9 @@
 
 package org.bytedeco.javacpp.tools;
 
+import org.bytedeco.javacpp.ClassProperties;
+import org.bytedeco.javacpp.Loader;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -32,8 +35,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import org.bytedeco.javacpp.ClassProperties;
-import org.bytedeco.javacpp.Loader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * The Parser, just like the Generator, is a mess that is not meant to support the
@@ -1700,6 +1703,32 @@ public class Parser {
         return params;
     }
 
+    static String incorporateConstAnnotation(String annotations, int constValueIndex, boolean constValue) {
+        int start = annotations.indexOf("@Const");
+        int end = annotations.indexOf("@", start + 1);
+        if (end == -1) {
+            end = annotations.length();
+        }
+        String prefix = annotations.substring(0, start);
+        String constAnnotation = annotations.substring(start, end);
+        String suffix = " " + annotations.substring(end, annotations.length());
+
+        String boolPatternStr = "(true|false)";
+        Pattern boolPattern = Pattern.compile(boolPatternStr);
+        Matcher matcher = boolPattern.matcher(constAnnotation);
+
+        /** default value same with {@link org.bytedeco.javacpp.annotation.Const} **/
+        boolean constArray[] = {true, false, false};
+        int index = 0;
+        while (matcher.find()) {
+            constArray[index++] = Boolean.parseBoolean(matcher.group(1));
+        }
+        constArray[constValueIndex] = constValue;
+
+        String incorporatedConstAnnotation = "@Const({" + constArray[0] + ", " + constArray[1] + ", " + constArray[2] + "})";
+        return prefix + incorporatedConstAnnotation + suffix;
+    }
+
     boolean function(Context context, DeclarationList declList) throws ParserException {
         int backIndex = tokens.index;
         String spacing = tokens.get().spacing;
@@ -1903,6 +1932,14 @@ public class Parser {
                     tokens.next().expect(';');
                 }
                 tokens.next();
+            }
+
+            if (decl.constMember) {
+                if (type.annotations.contains("@Const")) {
+                    type.annotations = incorporateConstAnnotation(type.annotations, 2, true);
+                } else {
+                    type.annotations += "@Const({false, false, true}) ";
+                }
             }
 
             // add @Virtual annotation on user request only, inherited through context
@@ -2733,7 +2770,7 @@ public class Parser {
         String modifiers = "public static ", constructors = "";
         boolean implicitConstructor = true, defaultConstructor = false, longConstructor = false,
                 pointerConstructor = false, abstractClass = info != null && info.purify && !ctx.virtualize,
-                havePureConst = false, haveVariables = false;
+                allPureConst = true, haveVariables = false;
         for (Declaration d : declList2) {
             if (d.declarator != null && d.declarator.type != null && d.declarator.type.using && decl.text != null) {
                 // inheriting constructors
@@ -2754,10 +2791,10 @@ public class Parser {
                 pointerConstructor |= paramDcls.length == 1 && paramDcls[0].type.javaName.equals("Pointer") && !d.inaccessible;
             }
             abstractClass |= d.abstractMember;
-            havePureConst |= d.constMember && d.abstractMember;
+            allPureConst &= d.constMember && d.abstractMember;
             haveVariables |= d.variable;
         }
-        if (havePureConst && ctx.virtualize) {
+        if (allPureConst && ctx.virtualize) {
             modifiers = "@Const " + modifiers;
         }
         if (!anonymous) {


### PR DESCRIPTION
``` cpp
#ifndef CACHE_EXECUTOR_H
#define CACHE_EXECUTOR_H

#include <string>

namespace tutor {

class CacheExecutor {

 public:

  virtual ~CacheExecutor() {}

  virtual void ReadCacheToBuffer(const std::string& key, char buffer, int max_buffer_len) const = 0;
  virtual void WriteCache(const std::string& key, char value) = 0;
  virtual void DeleteCache(const std::string& key) = 0;
};
}
#endif /* CACHE_EXECUTOR_H<INCLUDE>_ */

```

For the code above, javacpp generates mismatched cpp class.

- Only the first function is `const`, but in the generated cpp class, all functions is `const` and `@Const` is on the class `CacheExecutor`, not on the function level.
- Missing `const` for function arguments.