### PR TITLE
Significant performance improvements to Pointer.deallocator

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -326,12 +326,12 @@ public class Pointer implements AutoCloseable {
         }
 
         final void remove() {
-          if (refs.remove(this)) {
-              // decrement totalBytes here, but physical bytes are only updated lazily
-              totalBytes.addAndGet(-bytes);
-          } else {
-              throw new IllegalStateException("Pointer already removed");
-          }
+            if (refs.remove(this)) {
+                // decrement totalBytes here, but physical bytes are only updated lazily
+                totalBytes.addAndGet(-bytes);
+            } else {
+                throw new IllegalStateException("Pointer already removed");
+            }
         }
 
         @Override public void clear() {
@@ -657,7 +657,7 @@ public class Pointer implements AutoCloseable {
             }
             deallocator.deallocate();
             address = 0;
-        } else synchronized(DeallocatorReference.class) {
+        } else {
             for (DeallocatorReference r : DeallocatorReference.refs) {
                 if (r.deallocator == deallocator) {
                     r.deallocator = null;

--- a/src/test/java/org/bytedeco/javacpp/IndexerTest.java
+++ b/src/test/java/org/bytedeco/javacpp/IndexerTest.java
@@ -59,11 +59,11 @@ public class IndexerTest {
         Loader.load(c);
 
         // work around OutOfMemoryError when testing long indexing
-        Pointer.DeallocatorReference.totalBytes -= 1L << 48;
+        Pointer.DeallocatorReference.totalBytes.addAndGet(-(1L << 48));
     }
 
     @AfterClass public static void tearDownClass() throws Exception {
-        Pointer.DeallocatorReference.totalBytes += 1L << 48;
+        Pointer.DeallocatorReference.totalBytes.addAndGet(1L << 48);
     }
 
     @Test public void testByteIndexer() {

--- a/src/test/java/org/bytedeco/javacpp/PointerTest.java
+++ b/src/test/java/org/bytedeco/javacpp/PointerTest.java
@@ -191,7 +191,7 @@ public class PointerTest {
         for (int j = 0; j < chunks - 1; j++) {
             pointers[j] = new BytePointer(chunkSize);
         }
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= (chunks - 1) * chunkSize * byteSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= (chunks - 1) * chunkSize * byteSize);
         try {
             fieldReference = pointers;
             new BytePointer(chunkSize);
@@ -206,9 +206,9 @@ public class PointerTest {
         // make sure garbage collection runs
         fieldReference = null;
         pointers[0] = new BytePointer(chunkSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes < (chunks - 1) * chunkSize * byteSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= chunkSize * byteSize);
-        System.out.println(Pointer.DeallocatorReference.totalBytes + " " + chunkSize * byteSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() < (chunks - 1) * chunkSize * byteSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= chunkSize * byteSize);
+        System.out.println(Pointer.DeallocatorReference.totalBytes.get() + " " + chunkSize * byteSize);
     }
 
     @Test public void testShortPointer() {
@@ -270,7 +270,7 @@ public class PointerTest {
         for (int j = 0; j < chunks - 1; j++) {
             pointers[j] = new ShortPointer(chunkSize);
         }
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= (chunks - 1) * chunkSize * shortSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= (chunks - 1) * chunkSize * shortSize);
         try {
             fieldReference = pointers;
             new ShortPointer(chunkSize);
@@ -285,9 +285,9 @@ public class PointerTest {
         // make sure garbage collection runs
         fieldReference = null;
         pointers[0] = new ShortPointer(chunkSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes < (chunks - 1) * chunkSize * shortSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= chunkSize * shortSize);
-        System.out.println(Pointer.DeallocatorReference.totalBytes + " " + chunkSize * shortSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() < (chunks - 1) * chunkSize * shortSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= chunkSize * shortSize);
+        System.out.println(Pointer.DeallocatorReference.totalBytes.get() + " " + chunkSize * shortSize);
     }
 
     @Test public void testIntPointer() {
@@ -349,7 +349,7 @@ public class PointerTest {
         for (int j = 0; j < chunks - 1; j++) {
             pointers[j] = new IntPointer(chunkSize);
         }
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= (chunks - 1) * chunkSize * intSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= (chunks - 1) * chunkSize * intSize);
         try {
             fieldReference = pointers;
             new IntPointer(chunkSize);
@@ -364,9 +364,9 @@ public class PointerTest {
         // make sure garbage collection runs
         fieldReference = null;
         pointers[0] = new IntPointer(chunkSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes < (chunks - 1) * chunkSize * intSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= chunkSize * intSize);
-        System.out.println(Pointer.DeallocatorReference.totalBytes + " " + chunkSize * intSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() < (chunks - 1) * chunkSize * intSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= chunkSize * intSize);
+        System.out.println(Pointer.DeallocatorReference.totalBytes.get() + " " + chunkSize * intSize);
     }
 
     @Test public void testLongPointer() {
@@ -428,7 +428,7 @@ public class PointerTest {
         for (int j = 0; j < chunks - 1; j++) {
             pointers[j] = new LongPointer(chunkSize);
         }
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= (chunks - 1) * chunkSize * longSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= (chunks - 1) * chunkSize * longSize);
         try {
             fieldReference = pointers;
             new LongPointer(chunkSize);
@@ -443,9 +443,9 @@ public class PointerTest {
         // make sure garbage collection runs
         fieldReference = null;
         pointers[0] = new LongPointer(chunkSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes < (chunks - 1) * chunkSize * longSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= chunkSize * longSize);
-        System.out.println(Pointer.DeallocatorReference.totalBytes + " " + chunkSize * longSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() < (chunks - 1) * chunkSize * longSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= chunkSize * longSize);
+        System.out.println(Pointer.DeallocatorReference.totalBytes.get() + " " + chunkSize * longSize);
     }
 
     @Test public void testFloatPointer() {
@@ -507,7 +507,7 @@ public class PointerTest {
         for (int j = 0; j < chunks - 1; j++) {
             pointers[j] = new FloatPointer(chunkSize);
         }
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= (chunks - 1) * chunkSize * floatSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= (chunks - 1) * chunkSize * floatSize);
         try {
             fieldReference = pointers;
             new FloatPointer(chunkSize);
@@ -522,9 +522,9 @@ public class PointerTest {
         // make sure garbage collection runs
         fieldReference = null;
         pointers[0] = new FloatPointer(chunkSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes < (chunks - 1) * chunkSize * floatSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= chunkSize * floatSize);
-        System.out.println(Pointer.DeallocatorReference.totalBytes + " " + chunkSize * floatSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() < (chunks - 1) * chunkSize * floatSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= chunkSize * floatSize);
+        System.out.println(Pointer.DeallocatorReference.totalBytes.get() + " " + chunkSize * floatSize);
     }
 
     @Test public void testDoublePointer() {
@@ -586,7 +586,7 @@ public class PointerTest {
         for (int j = 0; j < chunks - 1; j++) {
             pointers[j] = new DoublePointer(chunkSize);
         }
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= (chunks - 1) * chunkSize * doubleSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= (chunks - 1) * chunkSize * doubleSize);
         try {
             fieldReference = pointers;
             new DoublePointer(chunkSize);
@@ -601,9 +601,9 @@ public class PointerTest {
         // make sure garbage collection runs
         fieldReference = null;
         pointers[0] = new DoublePointer(chunkSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes < (chunks - 1) * chunkSize * doubleSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= chunkSize * doubleSize);
-        System.out.println(Pointer.DeallocatorReference.totalBytes + " " + chunkSize * doubleSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() < (chunks - 1) * chunkSize * doubleSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= chunkSize * doubleSize);
+        System.out.println(Pointer.DeallocatorReference.totalBytes.get() + " " + chunkSize * doubleSize);
     }
 
     @Test public void testCharPointer() {
@@ -665,7 +665,7 @@ public class PointerTest {
         for (int j = 0; j < chunks - 1; j++) {
             pointers[j] = new CharPointer(chunkSize);
         }
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= (chunks - 1) * chunkSize * charSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= (chunks - 1) * chunkSize * charSize);
         try {
             fieldReference = pointers;
             new CharPointer(chunkSize);
@@ -680,9 +680,9 @@ public class PointerTest {
         // make sure garbage collection runs
         fieldReference = null;
         pointers[0] = new CharPointer(chunkSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes < (chunks - 1) * chunkSize * charSize);
-        assertTrue(Pointer.DeallocatorReference.totalBytes >= chunkSize * charSize);
-        System.out.println(Pointer.DeallocatorReference.totalBytes + " " + chunkSize * charSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() < (chunks - 1) * chunkSize * charSize);
+        assertTrue(Pointer.DeallocatorReference.totalBytes.get() >= chunkSize * charSize);
+        System.out.println(Pointer.DeallocatorReference.totalBytes.get() + " " + chunkSize * charSize);
     }
 
     @Test public void testDeallocator() throws InterruptedException {


### PR DESCRIPTION
This improves thread contention when locking on the global lock for Pointer allocations in most cases.
The global lock can be a performance killer in highly parallel operations, even when memory pressures are not high.
In this change we do optimistic provisioning using Atomic operations, and only fall back to locking when there is memory pressure.

For the totalBytes and the internal linked list this was an easy change.  Switching to an `AtomicLong` and `ConcurrentLinkedQueue` helps in us being able to do those common actions without needing to lock.
The handling of the "PhysicalBytes" however is a bit different in this implementation.  We use an `AtomicLong` to approximate the size based off the internally stored bytes.  However on de-allocations this is NOT decremented (while totalBytes is decremented).  This means that one of two other methods will need to sync the physicalBytes back to reality.  The first (hopefully most likely) would be a sync that occurs every 1000 allocations.  The second would be that if we fail to allocate, we will do a `trim` which will sync this state as well.

@saudet give me your thoughts on this to resolve #231 

My biggest concerns are around how I am approximating the physical bytes.  If there is a better way to estimate the size, or if you think the sync interval needs to be different, let me know.  For my use case I could be syncing every million or two.  That said, these changes DRAMATICALLY speed up deeplearning4j's kmeans implementation for me.