### PR TITLE
#16 created ForceArrayCritical annotation to prevent copies of array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add new `@CriticalRegion` annotation to allow zero-copy access to data of Java arrays ([pull #254](https://github.com/bytedeco/javacpp/pull/254))
  * Allow `Builder` to create links for resource libraries even when no Java classes are built
  * Fix `Loader.cacheResource()` creating a subdirectory named "null" when caching a top-level file
  * Update `README.md` with reference to newly published [Mapping Recipes for C/C++ Libraries](https://github.com/bytedeco/javacpp/wiki/Mapping-Recipes)

--- a/src/main/java/org/bytedeco/javacpp/annotation/CriticalRegion.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/CriticalRegion.java
@@ -5,11 +5,10 @@ import org.bytedeco.javacpp.tools.Generator;
 import java.lang.annotation.*;
 
 /**
- * In some methods, {@link Generator} will generate code to transfer arrays from
- * JVM to native code using the Get/Release<primitivetype>ArrayElements methods.
- * However these methods copy the underlying data.
- * With this annotation, the generated code will always call the
- * Get/ReleasePrimitiveArrayCritical methods instead.
+ * In some methods, {@link Generator} will generate code to transfer arrays from the
+ * JVM to native code using the {@code Get/Release<primitivetype>ArrayElements} methods.
+ * However these methods copy the underlying data. With this annotation, the generated
+ * code will always call the {@code Get/ReleasePrimitiveArrayCritical} methods instead.
  *
  * @see Generator
  *

--- a/src/main/java/org/bytedeco/javacpp/annotation/CriticalRegion.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/CriticalRegion.java
@@ -1,0 +1,19 @@
+package org.bytedeco.javacpp.annotation;
+
+import org.bytedeco.javacpp.tools.Generator;
+
+import java.lang.annotation.*;
+
+/**
+ * In some methods, {@link Generator} will generate code to transfer arrays from
+ * JVM to native code using the Get/Release<primitivetype>ArrayElements methods.
+ * However these methods copy the underlying data.
+ * With this annotation, the generated code will always call the
+ * Get/ReleasePrimitiveArrayCritical methods instead.
+ *
+ * @see Generator
+ *
+ */
+@Documented @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface CriticalRegion { }

--- a/src/main/java/org/bytedeco/javacpp/tools/MethodInformation.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/MethodInformation.java
@@ -41,7 +41,8 @@ public class MethodInformation {
     Class<?>[] parameterTypes;
     Annotation[][] parameterAnnotations;
     boolean returnRaw, withEnv, overloaded, noOffset, deallocator, allocator, arrayAllocator,
-            bufferGetter, valueGetter, valueSetter, memberGetter, memberSetter, noReturnGetter;
+            bufferGetter, valueGetter, valueSetter, memberGetter, memberSetter, noReturnGetter,
+            criticalRegion;
     Method pairedMethod;
     Class<?> throwsException;
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/MethodInformation.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/MethodInformation.java
@@ -40,9 +40,8 @@ public class MethodInformation {
     boolean[] parameterRaw;
     Class<?>[] parameterTypes;
     Annotation[][] parameterAnnotations;
-    boolean returnRaw, withEnv, overloaded, noOffset, deallocator, allocator, arrayAllocator,
-            bufferGetter, valueGetter, valueSetter, memberGetter, memberSetter, noReturnGetter,
-            criticalRegion;
+    boolean criticalRegion, returnRaw, withEnv, overloaded, noOffset, deallocator, allocator, arrayAllocator,
+            bufferGetter, valueGetter, valueSetter, memberGetter, memberSetter, noReturnGetter;
     Method pairedMethod;
     Class<?> throwsException;
 }


### PR DESCRIPTION
* When this annotation is added to a method or a class, then all
wrapper calls will use Get/ReleasePrimitiveArrayCritical pair instead
of Get/Release<primitivetype>ArrayElements pair.