### PR TITLE
Fix android-{arm,x86}.clang builds with ndk r18

### DIFF
--- a/src/main/resources/org/bytedeco/javacpp/properties/android-arm-clang.properties
+++ b/src/main/resources/org/bytedeco/javacpp/properties/android-arm-clang.properties
@@ -3,7 +3,7 @@ platform.path.separator=:
 platform.source.suffix=.cpp
 platform.root=../android/android-ndk/
 platform.sysroot.prefix=--sysroot=
-platform.sysroot=platforms/android-14/arch-arm/
+platform.sysroot=platforms/android-16/arch-arm/
 platform.toolchain.prefix=-gcc-toolchain\u0020
 platform.toolchain=toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/
 platform.includepath.prefix=-I
@@ -16,7 +16,7 @@ platform.compiler.fastfpu=-mfpu=neon -ffast-math -Wl,--fix-cortex-a8
 platform.compiler.nodeprecated=-Wno-deprecated-declarations
 platform.compiler.noexceptions=-fno-exceptions -fno-rtti
 platform.compiler.nowarnings=-w
-platform.compiler.output=-Wl,-rpath,lib/ -D__ANDROID_API__=14 -DANDROID -ffunction-sections -funwind-tables -fstack-protector-strong -target armv7-none-linux-androideabi -march=armv7-a -mfloat-abi=softfp -Wall -static-libstdc++ -fPIC -shared -Wl,--no-undefined -z text -o\u0020
+platform.compiler.output=-Wl,-rpath,lib/ -D__ANDROID_API__=16 -DANDROID -ffunction-sections -funwind-tables -fstack-protector-strong -target armv7-none-linux-androideabi -march=armv7-a -mfloat-abi=softfp -Wall -static-libstdc++ -fPIC -shared -Wl,--no-undefined -z text -o\u0020
 platform.compiler.output2=-Wl,-soname,
 platform.linkpath.prefix=-L
 platform.linkpath=sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/

--- a/src/main/resources/org/bytedeco/javacpp/properties/android-x86-clang.properties
+++ b/src/main/resources/org/bytedeco/javacpp/properties/android-x86-clang.properties
@@ -3,7 +3,7 @@ platform.path.separator=:
 platform.source.suffix=.cpp
 platform.root=../android/android-ndk/
 platform.sysroot.prefix=--sysroot=
-platform.sysroot=platforms/android-14/arch-x86/
+platform.sysroot=platforms/android-16/arch-x86/
 platform.toolchain.prefix=-gcc-toolchain\u0020
 platform.toolchain=toolchains/x86-4.9/prebuilt/linux-x86_64/
 platform.includepath.prefix=-I
@@ -16,7 +16,7 @@ platform.compiler.fastfpu=-msse3 -ffast-math -mfpmath=sse
 platform.compiler.nodeprecated=-Wno-deprecated-declarations
 platform.compiler.noexceptions=-fno-exceptions -fno-rtti
 platform.compiler.nowarnings=-w
-platform.compiler.output=-Wl,-rpath,lib/ -D__ANDROID_API__=14 -DANDROID -ffunction-sections -funwind-tables -fstack-protector-strong -target i686-none-linux-android -march=i686 -mtune=atom -Wall -static-libstdc++ -fPIC -shared -Wl,--no-undefined -z text -o\u0020
+platform.compiler.output=-Wl,-rpath,lib/ -D__ANDROID_API__=16 -DANDROID -ffunction-sections -funwind-tables -fstack-protector-strong -target i686-none-linux-android -march=i686 -mtune=atom -Wall -static-libstdc++ -fPIC -shared -Wl,--no-undefined -z text -o\u0020
 platform.compiler.output2=-Wl,-soname,
 platform.linkpath.prefix=-L
 platform.linkpath=sources/cxx-stl/llvm-libc++/libs/x86/


### PR DESCRIPTION
The latest NDK doesn't ship with any android-14 libraries.

```
$ ls ~/Library/Android/sdk/ndk-bundle/platforms/
android-16  android-18  android-21  android-23  android-26  android-28
android-17  android-19  android-22  android-24  android-27

$ ls ~/Library/Android/sdk/ndk-bundle/platforms/android-16
arch-arm  arch-x86

$ ls ~/Library/Android/sdk/ndk-bundle/platforms/android-21
arch-arm  arch-arm64  arch-x86  arch-x86_64
```