### PR TITLE
Add support for linux-mips64el

### DIFF
--- a/src/main/resources/org/bytedeco/javacpp/properties/linux-mips64el.properties
+++ b/src/main/resources/org/bytedeco/javacpp/properties/linux-mips64el.properties
@@ -1,0 +1,25 @@
+platform=linux-mips64el
+platform.path.separator=:
+platform.source.suffix=.cpp
+platform.includepath.prefix=-I
+platform.includepath=
+platform.compiler=g++
+platform.compiler.cpp11=-std=c++11
+platform.compiler.debug=-O0 -g
+platform.compiler.default=-march=mips64 -mabi=64 -O3 -s
+platform.compiler.fastfpu=-ffast-math
+platform.compiler.nodeprecated=-Wno-deprecated-declarations
+platform.compiler.noexceptions=-fno-exceptions -fno-rtti
+platform.compiler.nowarnings=-w
+platform.compiler.output=-Wl,-rpath,$ORIGIN/ -Wl,-z,noexecstack -Wl,-Bsymbolic -Wall -fPIC -shared -o\u0020
+platform.linkpath.prefix=-L
+platform.linkpath.prefix2=-Wl,-rpath,
+platform.linkpath=
+platform.link.prefix=-l
+platform.link.suffix=
+platform.link=
+platform.framework.prefix=-F
+platform.framework.suffix=
+platform.framework=
+platform.library.prefix=lib
+platform.library.suffix=.so


### PR DESCRIPTION
Built on Loongson 3A3000 CPUs, which are little-endian MIPS64.
OS: Loongnix (based on Fedora 21, http://www.loongnix.org)
gcc: 4.9.3
glibc: 2.20
jdk: OpenJDK 8 ported by loongson (http://ftp.loongnix.org/toolchain/java/openjdk8/jdk8-mips64-8.tar.gz)