### PR TITLE
Fix cacheResource to work with jlink images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Loader.cacheResource()` with the "jrt" protocol as used by jlink ([pull #305](https://github.com/bytedeco/javacpp/pull/305))
  * Fix compiler error with `SharedPtrAdapter` and `UniquePtrAdapter` in callback functions ([pull #304](https://github.com/bytedeco/javacpp/pull/304))
  * Start `Pointer.DeallocatorThread` with `setContextClassLoader(null)` as required by containers ([issue deeplearning4j/deeplearning4j#7737](https://github.com/deeplearning4j/deeplearning4j/issues/7737))
  * Add `-print` command line option to access platform properties externally, for example, inside build scripts

--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -39,9 +39,6 @@ import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.attribute.FileTime;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -114,7 +111,6 @@ public class Loader {
         }
         PLATFORM = osName + "-" + osArch;
     }
-
 
     /**
      * Returns either the value of the "org.bytedeco.javacpp.platform"


### PR DESCRIPTION
When extracting resources from a jlink image, the `URLConnection` to the resource is an instance of `sun.net.protocol.jrt.JavaRuntimeURLConnection`. The loader failed to get a proper last modified date and content length in this case. This PR fixes this.

When reading from a `JavaRuntimeURLConnection`, `URLConnection.getContentLength` works, but` getLastModified` or `getDate` do not. We access the jrt file system and gets the last modified date of its root directory. The result is cached. I haven't found a simpler way to get the build time of the jlink image.