### PR TITLE
#309 Change maxphysicalbytes default to maxBytes + Runtime.maxMemory()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Change default value for `Pointer.maxPhysicalBytes` to `Pointer.maxBytes + Runtime.maxMemory()` ([pull #310](https://github.com/bytedeco/javacpp/pull/310))
  * Add `Loader.getVersion()` and `checkVersion()` to get versions of Maven artifacts and check against JavaCPP
  * Fix compile errors caused by `Generator` occurring with callback functions returning a value by reference
  * Make `Builder` expand entries from the user class path with `*` as basename to all JAR files in the directory

--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -325,7 +325,8 @@ public class Pointer implements AutoCloseable {
     static final long maxBytes;
 
     /** Maximum amount of memory reported by {@link #physicalBytes()} before forcing call to {@link System#gc()}.
-     * Set via "org.bytedeco.javacpp.maxphysicalbytes" system property, defaults to {@code 2 * Runtime.maxMemory()}. */
+     * Set via "org.bytedeco.javacpp.maxphysicalbytes" system property, defaults to {@code maxBytes + Runtime.maxMemory()}.
+     * If {@link #maxBytes} is also not set, this is equivalent to a default of {@code 2 * Runtime.maxMemory()}*/
     static final long maxPhysicalBytes;
 
     /** Maximum number of times to call {@link System#gc()} before giving up with {@link OutOfMemoryError}.
@@ -390,7 +391,7 @@ public class Pointer implements AutoCloseable {
         }
         maxBytes = m;
 
-        m = 2 * Runtime.getRuntime().maxMemory();
+        m = maxBytes + Runtime.getRuntime().maxMemory();
         s = System.getProperty("org.bytedeco.javacpp.maxphysicalbytes");
         s = System.getProperty("org.bytedeco.javacpp.maxPhysicalBytes", s);
         if (s != null && s.length() > 0) {


### PR DESCRIPTION
Fixes: https://github.com/bytedeco/javacpp/issues/309
Simple change as discussed in that issue.
Tests are passing locally (Windows) via "mvn clean test"