### PR TITLE
Packaging fixes for the OSGi branch

### DIFF
--- a/javacpp-tests-osgi/pom.xml
+++ b/javacpp-tests-osgi/pom.xml
@@ -69,17 +69,6 @@
         <version>${project.version}</version>
         <executions>
           <execution>
-            <id>javacpp.parser</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>build</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/generated-sources/javacpp</outputDirectory>
-              <classOrPackageName>org.bytedeco.javacpp.test.osgi.*</classOrPackageName>
-            </configuration>
-          </execution>
-          <execution>
             <id>javacpp.compiler</id>
             <phase>process-classes</phase>
             <goals>

--- a/javacpp/pom.xml
+++ b/javacpp/pom.xml
@@ -45,18 +45,16 @@
             <manifest>
               <mainClass>org.bytedeco.javacpp.tools.Builder</mainClass>
             </manifest>
-            <manifestSection>
-              <name>org/bytedeco/javacpp/</name>
-              <manifestEntries>
-                <Implementation-Title>${project.name}</Implementation-Title>
-                <Implementation-Vendor>Bytedeco</Implementation-Vendor>
-                <Implementation-Version>${project.version}</Implementation-Version>
-                <Specification-Title>${project.name}</Specification-Title>
-                <Specification-Vendor>Bytedeco</Specification-Vendor>
-                <Specification-Version>${project.version}</Specification-Version>
-                <Multi-Release>true</Multi-Release>
-              </manifestEntries>
-            </manifestSection>
+            
+            <manifestEntries>
+              <Implementation-Title>${project.name}</Implementation-Title>
+              <Implementation-Vendor>Bytedeco</Implementation-Vendor>
+              <Implementation-Version>${project.version}</Implementation-Version>
+              <Specification-Title>${project.name}</Specification-Title>
+              <Specification-Vendor>Bytedeco</Specification-Vendor>
+              <Specification-Version>${project.version}</Specification-Version>
+              <Multi-Release>true</Multi-Release>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
This PR:

* Further corrects the Manifest as discussed in #332 
* Fixes the Travis build issue identified in #331 so that the tests can run and snapshots be deployed

These changes are targeting the `osgi` branch, but they can easily be appended to #331 if there is a desire to include them in `master`.