### PR TITLE
Fix Native Library Loading in Osgi with a Java Helper Class

### DIFF
--- a/javacpp-maven-plugin/src/main/java/org/bytedeco/javacpp/tools/BuildMojo.java
+++ b/javacpp-maven-plugin/src/main/java/org/bytedeco/javacpp/tools/BuildMojo.java
@@ -228,6 +228,14 @@ public class BuildMojo extends AbstractMojo {
     @Parameter(property = "javacpp.skip", defaultValue = "false")
     boolean skip = false;
 
+    /** Generate the Java Helper. */
+    @Parameter(property = "javacpp.javaHelper", defaultValue = "true")
+    boolean javaHelper = true;
+
+    /** Set the Java Helper package name */
+    @Parameter(property = "javacpp.javaHelper.package")
+    String javaHelperPackage = null;
+
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     MavenProject project;
 
@@ -292,6 +300,8 @@ public class BuildMojo extends AbstractMojo {
                 log.debug("environmentVariables: " + environmentVariables);
                 log.debug("compilerOptions: " + Arrays.deepToString(compilerOptions));
                 log.debug("skip: " + skip);
+                log.debug("javaHelper: " + javaHelper);
+                log.debug("javaHelperPackage: " + javaHelperPackage);
             }
             if (targetDirectory != null) {
                 project.addCompileSourceRoot(targetDirectory);
@@ -336,7 +346,9 @@ public class BuildMojo extends AbstractMojo {
                     .buildCommand(buildCommand)
                     .workingDirectory(workingDirectory)
                     .environmentVariables(environmentVariables)
-                    .compilerOptions(compilerOptions);
+                    .compilerOptions(compilerOptions)
+                    .generateJavaHelper(javaHelper)
+                    .generatedJavaPackage(javaHelperPackage);
             Properties properties = builder.properties;
             String extension = properties.getProperty("platform.extension");
             log.info("Detected platform \"" + Loader.getPlatform() + "\"");

--- a/javacpp-tests-osgi/src/main/java/org/bytedeco/javacpp/test/osgi/Calc.java
+++ b/javacpp-tests-osgi/src/main/java/org/bytedeco/javacpp/test/osgi/Calc.java
@@ -11,18 +11,18 @@ public class Calc {
         // This line should be sufficient, but it
         // isn't because the library gets loaded by
         // the wrong classloader
-        //
-        // Loader.load();
+        
+         Loader.load();
         
         // This is what we need to happen in the scope
         // of the bundle containing the native code, 
         // not the JavaCPP bundle. Note that the call
         // to the Loader is just to force a wiring to
         // the JavaCPP package needed by the JNI code
-        
-        Loader.getPlatform();
-        
-        System.loadLibrary("jniCalc");
+//        
+//        Loader.getPlatform();
+//        
+//        System.loadLibrary("jniCalc");
     }
     
     private Calc() { }

--- a/javacpp-tests-osgi/src/main/java/org/bytedeco/javacpp/test/osgi/JavaCPPOsgiTest.java
+++ b/javacpp-tests-osgi/src/main/java/org/bytedeco/javacpp/test/osgi/JavaCPPOsgiTest.java
@@ -2,21 +2,13 @@ package org.bytedeco.javacpp.test.osgi;
 
 import static org.junit.Assert.assertEquals;
 
-import org.bytedeco.javacpp.ClassProperties;
-import org.bytedeco.javacpp.LoadEnabled;
 import org.junit.Test;
 
-public class JavaCPPOsgiTest implements LoadEnabled {
+public class JavaCPPOsgiTest {
     
     @Test
     public void testJavaCPP() {
         assertEquals(3, Calc.add(1, 2));
     }
-
-	@Override
-	public void init(ClassProperties properties) {
-		// TODO Auto-generated method stub
-		
-	}
 
 }


### PR DESCRIPTION
This PR is an option for solving the JavaCPP native library loading issue in a multi-classloader environment such as OSGi. As outlined in #332 the `Builder` has been extended to generate a small helper class which lives in the same package as the annotated class calling the `Loader` this can be used by the loader to ensure that the native library is loaded by the correct classloader.

A small number of API additions are required to ensure that the class context is available when loading the native library in the `Loader`, further additions are made to the `Builder` to allow configuration of the Java class generation.