### PR TITLE
Fix native library loading in OSGi using Runtime load0

### DIFF
--- a/javacpp-tests-osgi/src/main/java/org/bytedeco/javacpp/test/osgi/Calc.java
+++ b/javacpp-tests-osgi/src/main/java/org/bytedeco/javacpp/test/osgi/Calc.java
@@ -12,17 +12,17 @@ public class Calc {
         // isn't because the library gets loaded by
         // the wrong classloader
         //
-        // Loader.load();
+        Loader.load();
         
         // This is what we need to happen in the scope
         // of the bundle containing the native code, 
         // not the JavaCPP bundle. Note that the call
         // to the Loader is just to force a wiring to
         // the JavaCPP package needed by the JNI code
-        
-        Loader.getPlatform();
-        
-        System.loadLibrary("jniCalc");
+        //
+        //Loader.getPlatform();
+        //
+        //System.loadLibrary("jniCalc");
     }
     
     private Calc() { }


### PR DESCRIPTION
As discussed in #332, this is an alternative implementation for establishing the correct class context when loading native code. See also #336.

Note that the same API additions need to be made to `Loader` so that Class context can be passed in.

Signed-off-by: Tim Ward <timothyjward@apache.org>