### PR TITLE
Perform template substitution when parsing default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Perform template substitution in `Parser` also for default argument values ([pull #343](https://github.com/bytedeco/javacpp/pull/343))
  * Introduce `PointerScope.forClasses` to limit the `Pointer` classes that can be attached to a given instance
  * Add support for custom `Allocator` to `VectorAdapter` and custom `Deleter` to `UniquePtrAdapter`
  * Enable support for OSGi bundles ([pull #332](https://github.com/bytedeco/javacpp/pull/332))

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -1765,8 +1765,20 @@ public class Parser {
                         count2--;
                     }
 
-                    // try to qualify all the identifiers
+                    // perform template substitution
                     String cppName = token.value;
+                    if (context.templateMap != null) {
+                        String[] types = cppName.split("::");
+                        String separator = "";
+                        cppName = "";
+                        for (String t : types) {
+                            Type t2 = context.templateMap.get(t);
+                            cppName += separator + (t2 != null ? t2.cppName : t);
+                            separator = "::";
+                        }
+                    }
+
+                    // try to qualify all the identifiers
                     for (String name : context.qualify(cppName)) {
                         if (infoMap.getFirst(name, false) != null) {
                             cppName = name;


### PR DESCRIPTION
For reference, here's how I've patched for issue #342.  This change worked for me, but I won't claim it's the **correct** fix.