### PR TITLE
Fix OSGi integration tests on Windows

### DIFF
--- a/src/it/osgi/pom.xml
+++ b/src/it/osgi/pom.xml
@@ -27,6 +27,7 @@
       <properties>
         <os.kernel>linux</os.kernel>
         <os.name>linux</os.name>
+        <os.req>linux</os.req>
         <lib.name>libjniCalc.so</lib.name>
       </properties>
     </profile>
@@ -38,6 +39,7 @@
       <properties>
         <os.kernel>darwin</os.kernel>
         <os.name>macosx</os.name>
+        <os.req>macosx</os.req>
         <lib.name>libjniCalc.dylib</lib.name>
       </properties>
     </profile>
@@ -49,6 +51,7 @@
       <properties>
         <os.kernel>windows</os.kernel>
         <os.name>windows</os.name>
+        <os.req>win32</os.req>
         <lib.name>jniCalc.dll</lib.name>
       </properties>
     </profile>
@@ -232,7 +235,7 @@ Test-Cases: ${classes;NAMED;*Test}
 
 Bundle-NativeCode: \
  org/bytedeco/javacpp/test/osgi/${lib.path};\
- osname=${os.name}
+ osname=${os.req}
  
           ]]></bnd>
         </configuration>

--- a/src/it/osgi/pom.xml
+++ b/src/it/osgi/pom.xml
@@ -27,7 +27,7 @@
       <properties>
         <os.kernel>linux</os.kernel>
         <os.name>linux</os.name>
-        <os.req>linux</os.req>
+        <os.bundle>linux</os.bundle>
         <lib.name>libjniCalc.so</lib.name>
       </properties>
     </profile>
@@ -39,7 +39,7 @@
       <properties>
         <os.kernel>darwin</os.kernel>
         <os.name>macosx</os.name>
-        <os.req>macosx</os.req>
+        <os.bundle>macosx</os.bundle>
         <lib.name>libjniCalc.dylib</lib.name>
       </properties>
     </profile>
@@ -51,7 +51,7 @@
       <properties>
         <os.kernel>windows</os.kernel>
         <os.name>windows</os.name>
-        <os.req>win32</os.req>
+        <os.bundle>win32</os.bundle>
         <lib.name>jniCalc.dll</lib.name>
       </properties>
     </profile>
@@ -235,7 +235,7 @@ Test-Cases: ${classes;NAMED;*Test}
 
 Bundle-NativeCode: \
  org/bytedeco/javacpp/test/osgi/${lib.path};\
- osname=${os.req}
+ osname=${os.bundle}
  
           ]]></bnd>
         </configuration>


### PR DESCRIPTION
Use a more portable name for the various flavours of windows

Tested on Window using AppVeyor and locally on MacOSX, when Travis builds the PR that will also give Linux coverage.

Signed-off-by: Tim Ward <timothyjward@apache.org>