### PR TITLE
Allow to override the 1:1 ratio between Xmx & off-heap amounts

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -421,7 +421,7 @@ public class Pointer implements AutoCloseable {
         }
     }
 
-    public static long parseBytes(String string) throws NumberFormatException {
+    public static long parseBytes(String string, long relativeMultiple) throws NumberFormatException {
         int i = 0;
         while (i < string.length()) {
             if (!Character.isDigit(string.charAt(i))) {
@@ -431,6 +431,7 @@ public class Pointer implements AutoCloseable {
         }
         long size = Long.parseLong(string.substring(0, i));
         switch (string.substring(i).trim().toLowerCase()) {
+            case "%": size = size * relativeMultiple / 100; break;
             case "t": case "tb": size *= 1024L; /* no break */
             case "g": case "gb": size *= 1024L; /* no break */
             case "m": case "mb": size *= 1024L; /* no break */
@@ -457,7 +458,7 @@ public class Pointer implements AutoCloseable {
         s = System.getProperty("org.bytedeco.javacpp.maxBytes", s);
         if (s != null && s.length() > 0) {
             try {
-                m = parseBytes(s);
+                m = parseBytes(s, m);
             } catch (NumberFormatException e) {
                 throw new RuntimeException(e);
             }
@@ -469,7 +470,7 @@ public class Pointer implements AutoCloseable {
         s = System.getProperty("org.bytedeco.javacpp.maxPhysicalBytes", s);
         if (s != null && s.length() > 0) {
             try {
-                m = parseBytes(s);
+                m = parseBytes(s, m);
             } catch (NumberFormatException e) {
                 throw new RuntimeException(e);
             }

--- a/src/test/java/org/bytedeco/javacpp/PointerTest.java
+++ b/src/test/java/org/bytedeco/javacpp/PointerTest.java
@@ -1031,4 +1031,19 @@ public class PointerTest {
         }
         assertTrue(floatPointer.isNull());
     }
+
+    @Test public void testParseBytesWithRelativeUnits() {
+        System.out.println("ParseBytesWithRelativeUnits");
+        long arbitraryAmountOfMemory = 300000;
+
+        assertEquals(0, Pointer.parseBytes("0%", arbitraryAmountOfMemory));
+        assertEquals(arbitraryAmountOfMemory * 10 / 100, Pointer.parseBytes("10%", arbitraryAmountOfMemory));
+        try {
+            System.out.println("Note: NumberFormatException should get thrown here and printed below.");
+            Pointer.parseBytes("%", arbitraryAmountOfMemory);
+            fail("NumberFormatException should have been thrown.");
+        } catch (NumberFormatException e) {
+            System.out.println(e);
+        }
+    }
 }


### PR DESCRIPTION
As discussed in https://github.com/eclipse/deeplearning4j/issues/8435