### PR TITLE
Fix type javaNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Let `Parser` rename types using `Info.javaNames` in addition to `valueTypes` and `pointerTypes` ([pull #367](https://github.com/bytedeco/javacpp/pull/367))
  * Consider `Pointer` values `maxBytes` or `maxPhysicalBytes` suffixed with `%` as relative to `Runtime.maxMemory()` ([pull #365](https://github.com/bytedeco/javacpp/pull/365))
  * Prevent `Parser` from considering `constexpr operator` declarations as `const` types
  * Fix on `Loader.load()` the default library name of classes without `@Properties(target=..., global=...)`

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -827,7 +827,10 @@ public class Parser {
             } else if (info.pointerTypes != null && info.pointerTypes.length > 0) {
                 type.javaName = info.pointerTypes[0];
                 type.javaNames = info.pointerTypes;
-            }
+            } else if (info.javaNames != null && info.javaNames.length > 0) {
+                type.javaName = info.javaNames[0];
+                type.javaNames = info.javaNames;
+           }
         }
 
         if (type.operator) {


### PR DESCRIPTION
Fix missing handle of `javaNames` in method `type`.