### PR TITLE
* Use C++11 `override` keyword when overriding virtual functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+ * Apply in `Parser` missing `const` to parameters of `@Virtual` functions using adapters
+ * Use in `Generator` C++11 `override` keyword for `@Virtual` functions ([pull #373](https://github.com/bytedeco/javacpp/pull/373))
  * Speed up `Loader.load()` by caching results returned from `Loader.findLibrary()` ([issue #287](https://github.com/bytedeco/javacpp/issues/287))
  * Pick up `Info` correctly in `Parser` also for anonymous function pointers with `const` parameters
  * Make `Parser` apply `Info.translate` in the case of enumerators as well

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -368,6 +368,11 @@ public class Generator {
         out.println("    #define JavaCPP_noinline");
         out.println("    #define JavaCPP_hidden");
         out.println("#endif");
+        out.println("#if __cplusplus >= 201103L");
+        out.println("    #define JavaCPP_override override");
+        out.println("#else");
+        out.println("    #define JavaCPP_override");
+        out.println("#endif");
         out.println();
 
         if (loadSuffix == null) {
@@ -2709,7 +2714,7 @@ public class Generator {
                     member += usingLine + "\n    ";
                 }
                 member += "virtual " + returnConvention[0] + (returnConvention.length > 1 ? returnConvention[1] : "")
-                       +  methodInfo.memberName[0] + parameterDeclaration + ";\n    "
+                       +  methodInfo.memberName[0] + parameterDeclaration + " JavaCPP_override;\n    "
                        +  returnConvention[0] + "super_" + methodInfo.memberName[0] + nonconstParamDeclaration + " { ";
                 if (methodInfo.method.getAnnotation(Virtual.class).value()) {
                     member += "throw JavaCPP_exception(\"Cannot call pure virtual function " + valueTypeName + "::" + methodInfo.memberName[0] + "().\"); }";

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -922,6 +922,9 @@ public class Parser {
                 cast += "*";
             }
         }
+        if (type.constValue) {
+            cast = "const " + cast;
+        }
         if (type.constPointer) {
             dcl.constPointer = true;
             // ignore, const pointers are not useful in generated code


### PR DESCRIPTION
It is useful for detecting subtle errors in generated signatures at compile time.