### PR TITLE
Fix exception when running jlink image with JDK13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix exception in `Loader` when running jlink image with JDK 13+ ([pull #375](https://github.com/bytedeco/javacpp/pull/375))
  * Fix errors with `@Virtual @Name("operator ...")` in `Generator` by using Java names for C++ ([issue #362](https://github.com/bytedeco/javacpp/issues/362))
  * Apply in `Parser` missing `const` to parameters of `@Virtual` functions using adapters
  * Use in `Generator` C++11 `override` keyword for `@Virtual` functions ([pull #373](https://github.com/bytedeco/javacpp/pull/373))

--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -500,7 +500,7 @@ public class Loader {
                   size = Files.size(path);
                 } catch (java.nio.file.NoSuchFileException e) {
                   // Work around bug JDK-8216553
-                  path = Paths.get(new URI("jrt", "/modules"+p, null));
+                  path = Paths.get(new URI("jrt", "/modules" + p, null));
                   size = Files.size(path);
                 }
                 timestamp = Files.getLastModifiedTime(path).toMillis();

--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -493,11 +493,16 @@ public class Loader {
             }
         } else if (resourceURL.getProtocol().equals("jrt")) {
             String p = resourceURL.getPath();
-            if (!p.startsWith("/modules")) p = "/modules" + p; // Work around bug JDK-8216553
             try {
                 // urlConnection.getContentLength() would work on jrt URL, but not getLastModified()
                 Path path = Paths.get(new URI("jrt", p, null)); // Remove fragment
-                size = Files.size(path);
+                try {
+                  size = Files.size(path);
+                } catch (java.nio.file.NoSuchFileException e) {
+                  // Work around bug JDK-8216553
+                  path = Paths.get(new URI("jrt", "/modules"+p, null));
+                  size = Files.size(path);
+                }
                 timestamp = Files.getLastModifiedTime(path).toMillis();
             } catch (URISyntaxException e) { // Should not happen
                 size = 0;


### PR DESCRIPTION
JavaCPP had a workround for openjdk bug [8216553](https://bugs.openjdk.java.net/browse/JDK-8216553).
The bug seems now fixed (in JDK 13.0.1), but not the way it was expected in the workaround. Running from a jlink image built with newer JDK causes exceptions like :
```
java.lang.ClassCastException: class jdk.internal.jimage.ImageReader$Resource cannot be cast to class jdk.internal.jimage.ImageReader$Directory
```
This PR should make things work in both JDK 12- and JDK13+.
