### PR TITLE
Add get/set String function with Charset to avoid throw UnsupportedEn…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+ * Prevent potential `NullPointerException` in `Loader.checkVersion()` ([pull #385](https://github.com/bytedeco/javacpp/pull/385))
+ * Allow using `Charset` to avoid `UnsupportedEncodingException` from `BytePointer` ([pull #384](https://github.com/bytedeco/javacpp/pull/384))
  * Add static `Pointer.isNull(Pointer p)` helper method, for convenience
  * Add `MoveAdapter` and corresponding `@StdMove` annotation to support objects that require `std::move` from C++11
  * Always use `File.pathSeparator` when passing multiple paths via the `BUILD_PATH` environment variable

--- a/src/main/java/org/bytedeco/javacpp/BytePointer.java
+++ b/src/main/java/org/bytedeco/javacpp/BytePointer.java
@@ -25,6 +25,8 @@ package org.bytedeco.javacpp;
 import java.io.UnsupportedEncodingException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
 import org.bytedeco.javacpp.annotation.Cast;
 import org.bytedeco.javacpp.annotation.ValueGetter;
 import org.bytedeco.javacpp.annotation.ValueSetter;
@@ -49,6 +51,18 @@ public class BytePointer extends Pointer {
             throws UnsupportedEncodingException {
         this(s.getBytes(charsetName).length + 1);
         putString(s, charsetName);
+    }
+    /**
+     * Allocates enough memory for the encoded string and actually encodes it
+     * in the named charset before copying it.
+     *
+     * @param s the String to encode and copy
+     * @param charset the charset in which the bytes are encoded
+     * @see #putString(String, String)
+     */
+    public BytePointer(String s, Charset charset) {
+        this(s.getBytes(charset).length + 1);
+        putString(s, charset);
     }
     /**
      * Allocates enough memory for the encoded string and actually encodes it
@@ -153,6 +167,16 @@ public class BytePointer extends Pointer {
         return new String(getStringBytes(), charsetName);
     }
     /**
+     * Decodes the native bytes assuming they are encoded in the named charset.
+     * Assumes a null-terminated string if {@code limit <= position}.
+     *
+     * @param charset the charset in which the bytes are encoded
+     * @return a String from the null-terminated string
+     */
+    public String getString(Charset charset) {
+        return new String(getStringBytes(), charset);
+    }
+    /**
      * Decodes the native bytes assuming they are encoded in the platform's default charset.
      * Assumes a null-terminated string if {@code limit <= position}.
      *
@@ -177,6 +201,21 @@ public class BytePointer extends Pointer {
     public BytePointer putString(String s, String charsetName)
             throws UnsupportedEncodingException {
         byte[] bytes = s.getBytes(charsetName);
+        return put(bytes).put(bytes.length, (byte)0).limit(bytes.length);
+    }
+    /**
+     * Encodes the String into the named charset and copies it in native memory,
+     * including a terminating null byte.
+     * Sets the limit to just before the terminating null byte.
+     *
+     * @param s the String to encode and copy
+     * @param charset the charset in which to encode the bytes
+     * @return this
+     * @see String#getBytes(String)
+     * @see #put(byte[])
+     */
+    public BytePointer putString(String s, Charset charset) {
+        byte[] bytes = s.getBytes(charset);
         return put(bytes).put(bytes.length, (byte)0).limit(bytes.length);
     }
     /**

--- a/src/main/java/org/bytedeco/javacpp/BytePointer.java
+++ b/src/main/java/org/bytedeco/javacpp/BytePointer.java
@@ -54,11 +54,11 @@ public class BytePointer extends Pointer {
     }
     /**
      * Allocates enough memory for the encoded string and actually encodes it
-     * in the named charset before copying it.
+     * in the given charset before copying it.
      *
      * @param s the String to encode and copy
      * @param charset the charset in which the bytes are encoded
-     * @see #putString(String, String)
+     * @see #putString(String, Charset)
      */
     public BytePointer(String s, Charset charset) {
         this(s.getBytes(charset).length + 1);
@@ -167,7 +167,7 @@ public class BytePointer extends Pointer {
         return new String(getStringBytes(), charsetName);
     }
     /**
-     * Decodes the native bytes assuming they are encoded in the named charset.
+     * Decodes the native bytes assuming they are encoded in the given charset.
      * Assumes a null-terminated string if {@code limit <= position}.
      *
      * @param charset the charset in which the bytes are encoded
@@ -204,14 +204,14 @@ public class BytePointer extends Pointer {
         return put(bytes).put(bytes.length, (byte)0).limit(bytes.length);
     }
     /**
-     * Encodes the String into the named charset and copies it in native memory,
+     * Encodes the String into the given charset and copies it in native memory,
      * including a terminating null byte.
      * Sets the limit to just before the terminating null byte.
      *
      * @param s the String to encode and copy
      * @param charset the charset in which to encode the bytes
      * @return this
-     * @see String#getBytes(String)
+     * @see String#getBytes(Charset)
      * @see #put(byte[])
      */
     public BytePointer putString(String s, Charset charset) {

--- a/src/main/java/org/bytedeco/javacpp/PointerPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/PointerPointer.java
@@ -23,6 +23,7 @@
 package org.bytedeco.javacpp;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 
 /**
  * The peer class to native pointers and arrays of {@code void*}.
@@ -51,6 +52,16 @@ public class PointerPointer<P extends Pointer> extends Pointer {
      */
     public PointerPointer(String[] array, String charsetName) throws UnsupportedEncodingException {
         this(array.length); putString(array, charsetName);
+    }
+    /**
+     * Allocates enough memory for the array of strings and copies it.
+     *
+     * @param array the array of strings to copy
+     * @param charset the charset in which the bytes are encoded
+     * @see #putString(String[], String)
+     */
+    public PointerPointer(String[] array, Charset charset) {
+        this(array.length); putString(array, charset);
     }
     /**
      * Allocates enough memory for the array and copies it.
@@ -162,6 +173,12 @@ public class PointerPointer<P extends Pointer> extends Pointer {
         BytePointer p = (BytePointer)get((Class<P>)BytePointer.class, i);
         return p != null ? p.getString(charsetName) : null;
     }
+    /** @return {@code get(BytePointer.class, i).getString(charset)}
+     *  @see BytePointer#getString(Charset) */
+    public String getString(long i, Charset charset) {
+        BytePointer p = (BytePointer)get((Class<P>)BytePointer.class, i);
+        return p != null ? p.getString(charset) : null;
+    }
 
     /**
      * Creates one by one a new {@link BytePointer} for each {@link String},
@@ -190,6 +207,21 @@ public class PointerPointer<P extends Pointer> extends Pointer {
         pointerArray = (P[])new BytePointer[array.length];
         for (int i = 0; i < array.length; i++) {
             pointerArray[i] = array[i] != null ? (P)new BytePointer(array[i], charsetName) : null;
+        }
+        return put(pointerArray);
+    }
+    /**
+     * Creates one by one a new {@link BytePointer} for each {@link String},
+     * and writes them into the native {@code void*} array.
+     *
+     * @param array the array of {@link String} to read from
+     * @param charset the charset in which the bytes are encoded
+     * @return this
+     */
+    public PointerPointer<P> putString(String[] array, Charset charset) {
+        pointerArray = (P[])new BytePointer[array.length];
+        for (int i = 0; i < array.length; i++) {
+            pointerArray[i] = array[i] != null ? (P)new BytePointer(array[i], charset) : null;
         }
         return put(pointerArray);
     }


### PR DESCRIPTION
Current BytePointer and PointerPointer class getString() and putString() API takes charsetName as parameter and throws UnsupportedEncodingException. This makes it harder for developer using those APIs.

getString() and putString() API should take Charset as parameter to avoid UnsupportedEncodingException handling.