### PR TITLE
Fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Deprecate but also fix `Indexer.rows()`, `cols()`, `width()`, `height()`, and `channels()` ([pull #390](https://github.com/bytedeco/javacpp/pull/390))
  * Fix `Parser` producing invalid wrappers for basic containers like `std::set<std::pair<...> >`
  * Add compiler options for C++98, C++03, C++14, and C++17 to platform properties files ([pull #389](https://github.com/bytedeco/javacpp/pull/389))
  * Remove default compiler options from `linux-armhf.properties` that work mostly only for Raspberry Pi

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -79,15 +79,15 @@ public abstract class Indexer implements AutoCloseable {
     public long stride(int i) { return strides[i]; }
 
     /** Returns {@code sizes[0]} if the number of dimensions is 3, else returns -1 */
-    public long rows() { return sizes.length == 3 ? sizes[0] : -1; }
+    @Deprecated public long rows() { return sizes.length == 3 ? sizes[0] : -1; }
     /** Returns {@code sizes[1]} if the number of dimensions is 3, else returns -1 */
-    public long cols() { return sizes.length == 3 ? sizes[1] : -1; }
+    @Deprecated public long cols() { return sizes.length == 3 ? sizes[1] : -1; }
     /** Returns {@code sizes[1]} if the number of dimensions is 3, else returns -1 */
-    public long width() { return sizes.length == 3 ? sizes[1] : -1; }
+    @Deprecated public long width() { return sizes.length == 3 ? sizes[1] : -1; }
     /** Returns {@code sizes[0]} if the number of dimensions is 3, else returns -1 */
-    public long height() { return sizes.length == 3 ? sizes[0] : -1; }
+    @Deprecated public long height() { return sizes.length == 3 ? sizes[0] : -1; }
     /** Returns {@code sizes[2]} if the number of dimensions is 3, else returns -1 */
-    public long channels() { return sizes.length == 3 ? sizes[2] : -1; }
+    @Deprecated public long channels() { return sizes.length == 3 ? sizes[2] : -1; }
 
     protected static final long checkIndex(long i, long size) {
         if (i < 0 || i >= size) {

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -78,16 +78,16 @@ public abstract class Indexer implements AutoCloseable {
     /** Returns {@code strides[i]} */
     public long stride(int i) { return strides[i]; }
 
-    /** Returns {@code sizes[0]} if the number of dimensions is 3, else returns -1 */
-    @Deprecated public long rows() { return sizes.length == 3 ? sizes[0] : -1; }
-    /** Returns {@code sizes[1]} if the number of dimensions is 3, else returns -1 */
-    @Deprecated public long cols() { return sizes.length == 3 ? sizes[1] : -1; }
-    /** Returns {@code sizes[1]} if the number of dimensions is 3, else returns -1 */
-    @Deprecated public long width() { return sizes.length == 3 ? sizes[1] : -1; }
-    /** Returns {@code sizes[0]} if the number of dimensions is 3, else returns -1 */
-    @Deprecated public long height() { return sizes.length == 3 ? sizes[0] : -1; }
-    /** Returns {@code sizes[2]} if the number of dimensions is 3, else returns -1 */
-    @Deprecated public long channels() { return sizes.length == 3 ? sizes[2] : -1; }
+    /** Returns {@code sizes.length > 0 && sizes.length < 4 ? sizes[0] : -1} */
+    @Deprecated public long rows() { return sizes.length > 0 && sizes.length < 4 ? sizes[0] : -1; }
+    /** Returns {@code sizes.length > 1 && sizes.length < 4 ? sizes[1] : -1} */
+    @Deprecated public long cols() { return sizes.length > 1 && sizes.length < 4 ? sizes[1] : -1; }
+    /** Returns {@code sizes.length > 1 && sizes.length < 4 ? sizes[1] : -1} */
+    @Deprecated public long width() { return sizes.length > 1 && sizes.length < 4 ? sizes[1] : -1; }
+    /** Returns {@code sizes.length > 0 && sizes.length < 4 ? sizes[0] : -1} */
+    @Deprecated public long height() { return sizes.length > 0 && sizes.length < 4 ? sizes[0] : -1; }
+    /** Returns {@code sizes.length > 2 && sizes.length < 4 ? sizes[2] : -1} */
+    @Deprecated public long channels() { return sizes.length > 2 && sizes.length < 4 ? sizes[2] : -1; }
 
     protected static final long checkIndex(long i, long size) {
         if (i < 0 || i >= size) {

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -87,7 +87,7 @@ public abstract class Indexer implements AutoCloseable {
     /** Returns {@code sizes[0]} if the number of dimensions is 3, else returns -1 */
     public long height() { return sizes.length == 3 ? sizes[0] : -1; }
     /** Returns {@code sizes[2]} if the number of dimensions is 3, else returns -1 */
-    public long channels() { return sizes.length == 3 ? sizes[2] : 1; }
+    public long channels() { return sizes.length == 3 ? sizes[2] : -1; }
 
     protected static final long checkIndex(long i, long size) {
         if (i < 0 || i >= size) {

--- a/src/test/java/org/bytedeco/javacpp/IndexerTest.java
+++ b/src/test/java/org/bytedeco/javacpp/IndexerTest.java
@@ -73,6 +73,13 @@ public class IndexerTest {
         Pointer.DeallocatorReference.totalBytes += 1L << 48;
     }
 
+    static class TestIndexer extends Indexer {
+        TestIndexer(long[] sizes) { super(sizes, Indexer.strides(sizes)); }
+        public void release() { }
+        public double getDouble(long... indices) { return 0; }
+        public Indexer putDouble(long[] indices, double value) { return this; }
+    }
+
     @Test public void testIndexer() {
         System.out.println("Indexer");
         long[] sizes = {640, 480, 3};
@@ -81,6 +88,27 @@ public class IndexerTest {
         assertEquals(1440, strides[0]);
         assertEquals(   3, strides[1]);
         assertEquals(   1, strides[2]);
+
+        TestIndexer indexer = new TestIndexer(sizes);
+        assertEquals(indexer.size(0), indexer.rows());
+        assertEquals(indexer.size(0), indexer.height());
+        assertEquals(indexer.size(1), indexer.cols());
+        assertEquals(indexer.size(1), indexer.width());
+        assertEquals(indexer.size(2), indexer.channels());
+
+        indexer = new TestIndexer(new long[] {640, 480});
+        assertEquals(indexer.size(0), indexer.rows());
+        assertEquals(indexer.size(0), indexer.height());
+        assertEquals(indexer.size(1), indexer.cols());
+        assertEquals(indexer.size(1), indexer.width());
+        assertEquals(-1, indexer.channels());
+
+        indexer = new TestIndexer(new long[] {640});
+        assertEquals(indexer.size(0), indexer.rows());
+        assertEquals(indexer.size(0), indexer.height());
+        assertEquals(-1, indexer.cols());
+        assertEquals(-1, indexer.width());
+        assertEquals(-1, indexer.channels());
     }
 
     @Test public void testByteIndexer() {


### PR DESCRIPTION
Very small fix: `channels()` is supposed to return -1 when `sizes.length!=3`, but instead is returning 1.

Out of curiosity is there a reason why in case of `sizes.length==2` we do not have `rows()` and `cols()` returning respectively `size[0]` and `size[1]`?
