### PR TITLE
Add sizes to Index to use in Indexer removing Deprecated annotations

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/indexer/HyperslabIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/HyperslabIndex.java
@@ -46,41 +46,51 @@ package org.bytedeco.javacpp.indexer;
  */
 public class HyperslabIndex extends StrideIndex {
 
-    protected long[] offsets;
-    protected long[] hyperslabStrides;
-    protected long[] counts;
-    protected long[] blocks;
-    protected long[] resultingSizes;
+    protected long[] selectionSizes;
+    protected long[] selectionOffsets;
+    protected long[] selectionStrides;
+    protected long[] selectionCounts;
+    protected long[] selectionBlocks;
 
-    public HyperslabIndex(long[] sizes, long[] offsets, long[] hyperslabStrides, long[] counts, long[] blocks) {
-        super(sizes);
-        this.offsets = offsets;
-        this.hyperslabStrides = hyperslabStrides;
-        this.counts = counts;
-        this.blocks = blocks;
+    public HyperslabIndex(long[] sizes,
+                          long[] selectionOffsets, long[] selectionStrides, long[] selectionCounts, long[] selectionBlocks) {
 
-        this.resultingSizes = new long[counts.length];
-        for (int i = 0; i < counts.length; i++) {
-            resultingSizes[i] = counts[i] * blocks[i];
+        this(sizes,defaultStrides(sizes),
+                selectionOffsets, selectionStrides, selectionCounts, selectionBlocks);
+    }
+
+    public HyperslabIndex(long[] sizes,
+                          long[] strides,
+                          long[] selectionOffsets, long[] selectionStrides, long[] selectionCounts, long[] selectionBlocks) {
+
+        super(sizes, strides);
+        this.selectionOffsets = selectionOffsets;
+        this.selectionStrides = selectionStrides;
+        this.selectionCounts = selectionCounts;
+        this.selectionBlocks = selectionBlocks;
+
+        this.selectionSizes = new long[selectionCounts.length];
+        for (int i = 0; i < selectionCounts.length; i++) {
+            this.selectionSizes[i] = selectionCounts[i] * selectionBlocks[i];
         }
     }
 
     @Override
     public long index(long i) {
-        return (offsets[0] + hyperslabStrides[0] * (i / blocks[0]) + (i % blocks[0])) * strides[0];
+        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * selectionStrides[0];
     }
 
     @Override
     public long index(long i, long j) {
-        return (offsets[0] + hyperslabStrides[0] * (i / blocks[0]) + (i % blocks[0])) * strides[0]
-                + (offsets[1] + hyperslabStrides[1] * (j / blocks[1]) + (j % blocks[1])) * strides[1];
+        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * selectionStrides[0]
+                + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * selectionStrides[1];
     }
 
     @Override
     public long index(long i, long j, long k) {
-        return (offsets[0] + hyperslabStrides[0] * (i / blocks[0]) + (i % blocks[0])) * strides[0]
-                + (offsets[1] + hyperslabStrides[1] * (j / blocks[1]) + (j % blocks[1])) * strides[1]
-                + (offsets[2] + hyperslabStrides[2] * (k / blocks[2]) + (k % blocks[2])) * strides[2];
+        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * selectionStrides[0]
+                + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * selectionStrides[1]
+                + (selectionOffsets[2] + selectionStrides[2] * (k / selectionBlocks[2]) + (k % selectionBlocks[2])) * selectionStrides[2];
     }
 
     @Override
@@ -88,14 +98,14 @@ public class HyperslabIndex extends StrideIndex {
         long index = 0;
         for (int i = 0; i < indices.length; i++) {
             long coordinate = indices[i];
-            long mappedCoordinate = offsets[i] + hyperslabStrides[i] * (coordinate / blocks[i]) + (coordinate % blocks[i]);
-            index += mappedCoordinate * strides[i];
+            long mappedCoordinate = selectionOffsets[i] + selectionStrides[i] * (coordinate / selectionBlocks[i]) + (coordinate % selectionBlocks[i]);
+            index += mappedCoordinate * selectionStrides[i];
         }
         return index;
     }
 
     @Override
     public long[] sizes() {
-        return resultingSizes;
+        return selectionSizes;
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/indexer/HyperslabIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/HyperslabIndex.java
@@ -46,32 +46,29 @@ package org.bytedeco.javacpp.indexer;
  */
 public class HyperslabIndex extends StrideIndex {
 
-    protected long[] selectionSizes;
     protected long[] selectionOffsets;
     protected long[] selectionStrides;
     protected long[] selectionCounts;
     protected long[] selectionBlocks;
 
-    public HyperslabIndex(long[] sizes,
-                          long[] selectionOffsets, long[] selectionStrides, long[] selectionCounts, long[] selectionBlocks) {
-
-        this(sizes, defaultStrides(sizes),
-                selectionOffsets, selectionStrides, selectionCounts, selectionBlocks);
+    /** Calls {@code HyperslabIndex(sizes, defaultStrides(sizes), selectionOffsets, selectionStrides, selectionCounts, selectionBlocks)}. */
+    public HyperslabIndex(long[] sizes, long[] selectionOffsets, long[] selectionStrides,
+            long[] selectionCounts, long[] selectionBlocks) {
+        this(sizes, defaultStrides(sizes), selectionOffsets, selectionStrides, selectionCounts, selectionBlocks);
     }
 
-    public HyperslabIndex(long[] sizes,
-                          long[] strides,
-                          long[] selectionOffsets, long[] selectionStrides, long[] selectionCounts, long[] selectionBlocks) {
-
+    /** Constructor to set the {@link #sizes}, {@link #strides}, {@link #selectionOffsets}, {@link #selectionStrides},
+     * {@link #selectionCounts}, and {@link #selectionBlocks}. Also updates the {@link #sizes} for the resulting selection. */
+    public HyperslabIndex(long[] sizes, long[] strides, long[] selectionOffsets, long[] selectionStrides,
+            long[] selectionCounts, long[] selectionBlocks) {
         super(sizes, strides);
         this.selectionOffsets = selectionOffsets;
         this.selectionStrides = selectionStrides;
         this.selectionCounts = selectionCounts;
         this.selectionBlocks = selectionBlocks;
 
-        this.selectionSizes = new long[selectionCounts.length];
         for (int i = 0; i < selectionCounts.length; i++) {
-            this.selectionSizes[i] = selectionCounts[i] * selectionBlocks[i];
+            this.sizes[i] = selectionCounts[i] * selectionBlocks[i];
         }
     }
 
@@ -83,14 +80,14 @@ public class HyperslabIndex extends StrideIndex {
     @Override
     public long index(long i, long j) {
         return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * strides[0]
-                + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * strides[1];
+             + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * strides[1];
     }
 
     @Override
     public long index(long i, long j, long k) {
         return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * strides[0]
-                + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * strides[1]
-                + (selectionOffsets[2] + selectionStrides[2] * (k / selectionBlocks[2]) + (k % selectionBlocks[2])) * strides[2];
+             + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * strides[1]
+             + (selectionOffsets[2] + selectionStrides[2] * (k / selectionBlocks[2]) + (k % selectionBlocks[2])) * strides[2];
     }
 
     @Override
@@ -102,10 +99,5 @@ public class HyperslabIndex extends StrideIndex {
             index += mappedCoordinate * strides[i];
         }
         return index;
-    }
-
-    @Override
-    public long[] sizes() {
-        return selectionSizes;
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/indexer/HyperslabIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/HyperslabIndex.java
@@ -55,7 +55,7 @@ public class HyperslabIndex extends StrideIndex {
     public HyperslabIndex(long[] sizes,
                           long[] selectionOffsets, long[] selectionStrides, long[] selectionCounts, long[] selectionBlocks) {
 
-        this(sizes,defaultStrides(sizes),
+        this(sizes, defaultStrides(sizes),
                 selectionOffsets, selectionStrides, selectionCounts, selectionBlocks);
     }
 
@@ -77,20 +77,20 @@ public class HyperslabIndex extends StrideIndex {
 
     @Override
     public long index(long i) {
-        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * selectionStrides[0];
+        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * strides[0];
     }
 
     @Override
     public long index(long i, long j) {
-        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * selectionStrides[0]
-                + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * selectionStrides[1];
+        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * strides[0]
+                + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * strides[1];
     }
 
     @Override
     public long index(long i, long j, long k) {
-        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * selectionStrides[0]
-                + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * selectionStrides[1]
-                + (selectionOffsets[2] + selectionStrides[2] * (k / selectionBlocks[2]) + (k % selectionBlocks[2])) * selectionStrides[2];
+        return (selectionOffsets[0] + selectionStrides[0] * (i / selectionBlocks[0]) + (i % selectionBlocks[0])) * strides[0]
+                + (selectionOffsets[1] + selectionStrides[1] * (j / selectionBlocks[1]) + (j % selectionBlocks[1])) * strides[1]
+                + (selectionOffsets[2] + selectionStrides[2] * (k / selectionBlocks[2]) + (k % selectionBlocks[2])) * strides[2];
     }
 
     @Override
@@ -99,7 +99,7 @@ public class HyperslabIndex extends StrideIndex {
         for (int i = 0; i < indices.length; i++) {
             long coordinate = indices[i];
             long mappedCoordinate = selectionOffsets[i] + selectionStrides[i] * (coordinate / selectionBlocks[i]) + (coordinate % selectionBlocks[i]);
-            index += mappedCoordinate * selectionStrides[i];
+            index += mappedCoordinate * strides[i];
         }
         return index;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/HyperslabIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/HyperslabIndex.java
@@ -50,6 +50,7 @@ public class HyperslabIndex extends StrideIndex {
     protected long[] hyperslabStrides;
     protected long[] counts;
     protected long[] blocks;
+    protected long[] resultingSizes;
 
     public HyperslabIndex(long[] sizes, long[] offsets, long[] hyperslabStrides, long[] counts, long[] blocks) {
         super(sizes);
@@ -57,6 +58,11 @@ public class HyperslabIndex extends StrideIndex {
         this.hyperslabStrides = hyperslabStrides;
         this.counts = counts;
         this.blocks = blocks;
+
+        this.resultingSizes = new long[counts.length];
+        for (int i = 0; i < counts.length; i++) {
+            resultingSizes[i] = counts[i] * blocks[i];
+        }
     }
 
     @Override
@@ -86,5 +92,10 @@ public class HyperslabIndex extends StrideIndex {
             index += mappedCoordinate * strides[i];
         }
         return index;
+    }
+
+    @Override
+    public long[] sizes() {
+        return resultingSizes;
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/indexer/Index.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Index.java
@@ -75,4 +75,7 @@ public abstract class Index {
      * @return index to access array or buffer
      */
     public abstract long index(long... indices);
+
+    /** Returns resulting sizes */
+    public abstract long[] sizes();
 }

--- a/src/main/java/org/bytedeco/javacpp/indexer/Index.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Index.java
@@ -48,9 +48,42 @@ public abstract class Index {
         return new StrideIndex(sizes, strides);
     }
 
-    /** Returns {@code new HyperslabIndex(sizes, offsets, hyperslabStrides, counts, blocks)}. */
-    public static Index create(long[] sizes, long[] offsets, long[] hyperslabStrides, long[] counts, long[] blocks) {
-        return new HyperslabIndex(sizes, offsets, hyperslabStrides, counts, blocks);
+    /** Returns {@code new HyperslabIndex(sizes, selectionOffsets, selectionStrides, selectionCounts, selectionBlocks)}. */
+    public static Index create(long[] sizes, long[] selectionOffsets, long[] selectionStrides,
+            long[] selectionCounts, long[] selectionBlocks) {
+        return new HyperslabIndex(sizes, selectionOffsets, selectionStrides, selectionCounts, selectionBlocks);
+    }
+
+    /** Returns {@code new HyperslabIndex(sizes, strides, selectionOffsets, selectionStrides, selectionCounts, selectionBlocks)}. */
+    public static Index create(long[] sizes, long[] strides, long[] selectionOffsets, long[] selectionStrides,
+            long[] selectionCounts, long[] selectionBlocks) {
+        return new HyperslabIndex(sizes, strides, selectionOffsets, selectionStrides, selectionCounts, selectionBlocks);
+    }
+
+    /**
+     * The number of elements in each dimension.
+     * These values are not typically used by the indexer.
+     */
+    protected final long[] sizes;
+
+    /** Constructor to set the {@link #sizes}. */
+    public Index(long... sizes) {
+        this.sizes = sizes;
+    }
+
+    /** Returns {@code sizes.length}. */
+    public int rank() {
+        return sizes.length;
+    }
+
+    /** Returns {@link #sizes}. */
+    public long[] sizes() {
+        return sizes;
+    }
+
+    /** Returns {@code sizes[i]}. */
+    public long size(int i) {
+        return sizes[i];
     }
 
     /** Returns {@code index(new long[] {i})}. */
@@ -75,7 +108,4 @@ public abstract class Index {
      * @return index to access array or buffer
      */
     public abstract long index(long... indices);
-
-    /** Returns resulting sizes */
-    public abstract long[] sizes();
 }

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -50,7 +50,7 @@ public abstract class Indexer implements AutoCloseable {
     }
 
     /** See {@link StrideIndex#sizes}. */
-    @Deprecated protected long[] sizes;
+    protected long[] sizes;
 
     /** See {@link StrideIndex#strides}. */
     @Deprecated protected long[] strides;
@@ -73,12 +73,12 @@ public abstract class Indexer implements AutoCloseable {
     }
 
     /** Returns {@link #sizes} or {@code null} if there are no sizes. */
-    @Deprecated public long[] sizes() { return sizes; }
+    public long[] sizes() { return sizes; }
     /** Returns {@link #strides} or {@code null} if there are no strides. */
     @Deprecated public long[] strides() { return strides; }
 
     /** Returns {@code sizes[i]} or {@code -1} if there are no sizes. */
-    @Deprecated public long size(int i) { return sizes != null ? sizes[i] : -1; }
+    public long size(int i) { return sizes != null ? sizes[i] : -1; }
     /** Returns {@code strides[i]} or {@code -1} if there are no strides. */
     @Deprecated public long stride(int i) { return strides != null ? strides[i] : -1; }
 

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -72,6 +72,8 @@ public abstract class Indexer implements AutoCloseable {
         this(Index.create(sizes, strides));
     }
 
+    public int rank() { return sizes.length; }
+
     /** Returns {@link #sizes} or {@code null} if there are no sizes. */
     public long[] sizes() { return sizes; }
     /** Returns {@link #strides} or {@code null} if there are no strides. */

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -151,7 +151,7 @@ public abstract class Indexer implements AutoCloseable {
     public abstract Indexer putDouble(long[] indices, double value);
 
     /** Returns a new Indexer using the same data, but with a different Index. */
-    public abstract Indexer reindex(Index index);
+    public abstract <I extends Indexer> I reindex(Index index);
 
     @Override public String toString() {
         long rows     = sizes.length > 0 ? sizes[0] : 1,

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -49,8 +49,8 @@ public abstract class Indexer implements AutoCloseable {
         release();
     }
 
-    /** See {@link StrideIndex#sizes}. */
-    protected long[] sizes;
+    /** See {@link Index#sizes}. */
+    @Deprecated protected long[] sizes;
 
     /** See {@link StrideIndex#strides}. */
     @Deprecated protected long[] strides;
@@ -72,15 +72,16 @@ public abstract class Indexer implements AutoCloseable {
         this(Index.create(sizes, strides));
     }
 
-    public int rank() { return sizes.length; }
+    /** Returns {@code index.rank()}. */
+    public int rank() { return index.rank(); }
 
-    /** Returns {@link #sizes} or {@code null} if there are no sizes. */
-    public long[] sizes() { return sizes; }
+    /** Returns {@code index.sizes()}. */
+    public long[] sizes() { return index.sizes(); }
     /** Returns {@link #strides} or {@code null} if there are no strides. */
     @Deprecated public long[] strides() { return strides; }
 
-    /** Returns {@code sizes[i]} or {@code -1} if there are no sizes. */
-    public long size(int i) { return sizes != null ? sizes[i] : -1; }
+    /** Returns {@code index.size(i)}. */
+    public long size(int i) { return index.size(i); }
     /** Returns {@code strides[i]} or {@code -1} if there are no strides. */
     @Deprecated public long stride(int i) { return strides != null ? strides[i] : -1; }
 

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -61,8 +61,8 @@ public abstract class Indexer implements AutoCloseable {
     /** Constructor to set the {@link #index}. */
     protected Indexer(Index index) {
         this.index = index;
+        this.sizes = index.sizes();
         if (index instanceof StrideIndex) {
-            this.sizes = ((StrideIndex)index).sizes();
             this.strides = ((StrideIndex)index).strides();
         }
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/OneIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/OneIndex.java
@@ -29,11 +29,11 @@ package org.bytedeco.javacpp.indexer;
  */
 public class OneIndex extends Index {
 
-    protected final long size;
+    protected final long[] sizes;
 
-    /** Constructor to set the {@link #size}. */
+    /** Constructor to set the {@link #sizes} as {@code new long[]{size}}. */
     public OneIndex(long size) {
-        this.size = size;
+        this.sizes = new long[]{size};
     }
 
     /** Returns {@code i}. */
@@ -54,5 +54,10 @@ public class OneIndex extends Index {
     /** Throws {@code new UnsupportedOperationException()}. */
     @Override public long index(long... indices) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long[] sizes() {
+        return sizes;
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/indexer/OneIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/OneIndex.java
@@ -29,11 +29,9 @@ package org.bytedeco.javacpp.indexer;
  */
 public class OneIndex extends Index {
 
-    protected final long[] sizes;
-
-    /** Constructor to set the {@link #sizes} as {@code new long[]{size}}. */
+    /** Constructor to set the {@link #sizes}. */
     public OneIndex(long size) {
-        this.sizes = new long[]{size};
+        super(size);
     }
 
     /** Returns {@code i}. */
@@ -51,16 +49,11 @@ public class OneIndex extends Index {
         throw new UnsupportedOperationException();
     }
 
-    /** Throws {@code new UnsupportedOperationException()}. */
+    /** Returns {@code indices[0]} if {@code indices.length == 1} or throws {@code new UnsupportedOperationException()}. */
     @Override public long index(long... indices) {
         if (indices.length == 1) {
             return indices[0];
         }
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long[] sizes() {
-        return sizes;
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/indexer/OneIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/OneIndex.java
@@ -53,6 +53,9 @@ public class OneIndex extends Index {
 
     /** Throws {@code new UnsupportedOperationException()}. */
     @Override public long index(long... indices) {
+        if (indices.length == 1) {
+            return indices[0];
+        }
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/bytedeco/javacpp/indexer/StrideIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/StrideIndex.java
@@ -42,12 +42,6 @@ public class StrideIndex extends Index {
     }
 
     /**
-     * The number of elements in each dimension.
-     * These values are not typically used by the indexer.
-     */
-    protected final long[] sizes;
-
-    /**
      * The number of elements to skip to reach the next element in a given dimension.
      * {@code strides[i] > strides[i + 1] && strides[strides.length - 1] == 1} preferred.
      */
@@ -60,13 +54,8 @@ public class StrideIndex extends Index {
 
     /** Constructor to set the {@link #sizes} and {@link #strides}. */
     public StrideIndex(long[] sizes, long[] strides) {
-        this.sizes = sizes;
+        super(sizes);
         this.strides = strides;
-    }
-
-    /** Returns {@link #sizes}. */
-    @Override public long[] sizes() {
-        return sizes;
     }
 
     /** Returns {@link #strides}. */

--- a/src/main/java/org/bytedeco/javacpp/indexer/StrideIndex.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/StrideIndex.java
@@ -65,7 +65,7 @@ public class StrideIndex extends Index {
     }
 
     /** Returns {@link #sizes}. */
-    public long[] sizes() {
+    @Override public long[] sizes() {
         return sizes;
     }
 


### PR DESCRIPTION
Getting back `sizes()` in `Indexer` and in `Index` as the maximum values of the indices.