### PR TITLE
Fixed java home path for latest JDKs from Oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Builder` for different "java.home" path returned by latest JDKs from Oracle ([pull #400](https://github.com/bytedeco/javacpp/pull/400))
  * Refactor `Builder` a little to work around issues with Gradle
  * Log as warnings `SecurityException` thrown on `Loader.getCacheDir()` instead of swallowing them
  * Fix memory leak that occurs with "org.bytedeco.javacpp.nopointergc" ([issue bytedeco/javacpp-presets#878](https://github.com/bytedeco/javacpp-presets/issues/878))

--- a/src/main/java/org/bytedeco/javacpp/tools/Builder.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Builder.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -123,59 +124,62 @@ public class Builder {
                        "jvm" + properties.getProperty("platform.link.suffix", "");
         final String jvmlib  = properties.getProperty("platform.library.prefix", "") +
                        "jvm" + properties.getProperty("platform.library.suffix", "");
-        final String[] jnipath = new String[2];
-        final String[] jvmpath = new String[2];
+        final HashSet<String> jnipath = new HashSet<>();
+        final HashSet<String> jvmpath = new HashSet<>();
         FilenameFilter filter = new FilenameFilter() {
             @Override public boolean accept(File dir, String name) {
                 if (new File(dir, "jni.h").exists()) {
-                    jnipath[0] = dir.getAbsolutePath();
+                    jnipath.add(dir.getAbsolutePath());
                 }
                 if (new File(dir, "jni_md.h").exists()) {
-                    jnipath[1] = dir.getAbsolutePath();
+                    jnipath.add(dir.getAbsolutePath());
                 }
                 if (new File(dir, jvmlink).exists()) {
-                    jvmpath[0] = dir.getAbsolutePath();
+                    jvmpath.add(dir.getAbsolutePath());
                 }
                 if (new File(dir, jvmlib).exists()) {
-                    jvmpath[1] = dir.getAbsolutePath();
+                    jvmpath.add(dir.getAbsolutePath());
                 }
                 return new File(dir, name).isDirectory();
             }
         };
-        File javaHome;
+        // Java home dir is the one returned by "java.home" or parent dir of it in older JDKs.
+        File[] javaHomes= new File[2];
         try {
-            javaHome = new File(System.getProperty("java.home")).getParentFile().getCanonicalFile();
+            javaHomes[0] = new File(System.getProperty("java.home")).getCanonicalFile();
+            javaHomes[1] = javaHomes[0].getParentFile().getCanonicalFile();
         } catch (IOException | NullPointerException e) {
             logger.warn("Could not include header files from java.home:" + e);
             return;
         }
-        ArrayList<File> dirs = new ArrayList<File>(Arrays.asList(javaHome.listFiles(filter)));
-        while (!dirs.isEmpty()) {
-            File d = dirs.remove(dirs.size() - 1);
-            String dpath = d.getPath();
-            File[] files = d.listFiles(filter);
-            if (dpath == null || files == null) {
-                continue;
-            }
-            for (File f : files) {
-                try {
-                    f = f.getCanonicalFile();
-                } catch (IOException e) { }
-                if (!dpath.startsWith(f.getPath())) {
-                    dirs.add(f);
+        for (File javaHome : javaHomes) {
+            ArrayList<File> dirs = new ArrayList<File>(Arrays.asList(javaHome.listFiles(filter)));
+            while (!dirs.isEmpty()) {
+                File d = dirs.remove(dirs.size() - 1);
+                String dpath = d.getPath();
+                File[] files = d.listFiles(filter);
+                if (dpath == null || files == null) {
+                    continue;
+                }
+                for (File f : files) {
+                    try {
+                        f = f.getCanonicalFile();
+                    } catch (IOException e) { }
+                    if (!dpath.startsWith(f.getPath())) {
+                        dirs.add(f);
+                    }
                 }
             }
-        }
-        if (jnipath[0] != null && jnipath[0].equals(jnipath[1])) {
-            jnipath[1] = null;
-        } else if (jnipath[0] == null) {
-            String macpath = "/System/Library/Frameworks/JavaVM.framework/Headers/";
-            if (new File(macpath).isDirectory()) {
-                jnipath[0] = macpath;
+            if (jnipath.isEmpty()) {
+                String macpath = "/System/Library/Frameworks/JavaVM.framework/Headers/";
+                if (new File(macpath).isDirectory()) {
+                    jnipath.add(macpath);
+                }
             }
-        }
-        if (jvmpath[0] != null && jvmpath[0].equals(jvmpath[1])) {
-            jvmpath[1] = null;
+            // Break searching if all needed paths are found
+            if (!jnipath.isEmpty() && !jvmpath.isEmpty()) break;
+            jnipath.clear();
+            jvmpath.clear();
         }
         properties.addAll("platform.includepath", jnipath);
         if (platform.equals(properties.getProperty("platform", platform))) {

--- a/src/main/java/org/bytedeco/javacpp/tools/Builder.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Builder.java
@@ -124,8 +124,8 @@ public class Builder {
                        "jvm" + properties.getProperty("platform.link.suffix", "");
         final String jvmlib  = properties.getProperty("platform.library.prefix", "") +
                        "jvm" + properties.getProperty("platform.library.suffix", "");
-        final HashSet<String> jnipath = new HashSet<>();
-        final HashSet<String> jvmpath = new HashSet<>();
+        final HashSet<String> jnipath = new HashSet<String>();
+        final HashSet<String> jvmpath = new HashSet<String>();
 
         FilenameFilter filter = new FilenameFilter() {
             @Override public boolean accept(File dir, String name) {
@@ -146,7 +146,7 @@ public class Builder {
         };
 
         // Java home dir is the one returned by "java.home" or parent dir of it in older JDKs.
-        File[] javaHomes= new File[2];
+        File[] javaHomes = new File[2];
         try {
             javaHomes[0] = new File(System.getProperty("java.home")).getCanonicalFile();
             javaHomes[1] = javaHomes[0].getParentFile().getCanonicalFile();
@@ -170,7 +170,9 @@ public class Builder {
                 for (File f : files) {
                     try {
                         f = f.getCanonicalFile();
-                    } catch (IOException e) { }
+                    } catch (IOException e) {
+                        f = f.getAbsoluteFile();
+                    }
                     if (!dpath.startsWith(f.getPath())) {
                         dirs.add(f);
                     }


### PR DESCRIPTION
Fix of java home path reported in https://github.com/bytedeco/javacpp/issues/398.

Tested on Linux (Java 8, 11, 14) and MacOS (Java 7, 9, 13).
Unfortunately I have no suitable Windows machine.

One thing that could be removed during merge are lines (I left it as it is since I do not understand the reason of it):
```java
                if (new File(dir, jvmlink).exists()) {
                    jvmpath.add(dir.getAbsolutePath());
                }
```
I do not see any reason to search for ```jvmlink``` file since ```jvmlink``` is a (at least on MacOS and Linux) string with ```-ljvm``` which is option for linker and not file to be found.