### PR TITLE
WIP: Use sun.misc.Unsafe in pointers and not in indexers

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/BoolPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/BoolPointer.java
@@ -71,7 +71,6 @@ public class BoolPointer extends Pointer {
     public BoolPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public BoolPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public BoolPointer position(long position) {
@@ -90,7 +89,7 @@ public class BoolPointer extends Pointer {
     public boolean get() { return get(0); }
     /** @return the i-th {@code bool} value of a native array
      * @param i*/
-    @Cast("bool") public native boolean get(long i);
+    @Cast("bool") public boolean get(long i) { return Raw.getInstance().getBool(address + i * sizeof()); }
     /** @return {@code put(0, b)} */
     public BoolPointer put(boolean b) { return put(0, b); }
     /**
@@ -100,5 +99,8 @@ public class BoolPointer extends Pointer {
      * @param b the {@code bool} value to copy
      * @return this
      */
-    public native BoolPointer put(long i, boolean b);
+    public BoolPointer put(long i, boolean b) {
+        Raw.getInstance().putBool(address + i * sizeof(), b);
+        return this;
+    }
 }

--- a/src/main/java/org/bytedeco/javacpp/BooleanPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/BooleanPointer.java
@@ -98,7 +98,6 @@ public class BooleanPointer extends Pointer {
     public BooleanPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public BooleanPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public BooleanPointer position(long position) {
@@ -119,7 +118,7 @@ public class BooleanPointer extends Pointer {
     /** @return {@code get(0)} */
     public boolean get() { return get(0); }
     /** @return the i-th {@code boolean} value of a native array */
-    public native boolean get(long i);
+    public boolean get(long i) { return Raw.getInstance().getByte(address + i * sizeof()) != 0; }
     /** @return {@code put(0, b)} */
     public BooleanPointer put(boolean b) { return put(0, b); }
     /**
@@ -129,7 +128,10 @@ public class BooleanPointer extends Pointer {
      * @param b the {@code boolean} value to copy
      * @return this
      */
-    public native BooleanPointer put(long i, boolean b);
+    public BooleanPointer put(long i, boolean b) {
+        Raw.getInstance().putByte(address + i * sizeof(), (byte) (b ? 1 : 0));
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public BooleanPointer get(boolean[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/BytePointer.java
+++ b/src/main/java/org/bytedeco/javacpp/BytePointer.java
@@ -138,7 +138,6 @@ public class BytePointer extends Pointer {
     public BytePointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public BytePointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public BytePointer position(long position) {
@@ -248,7 +247,7 @@ public class BytePointer extends Pointer {
     /** @return {@code get(0)} */
     public byte get() { return get(0); }
     /** @return the i-th {@code byte} value of a native array */
-    public native byte get(long i);
+    public byte get(long i) { return Raw.getInstance().getByte(address + i * sizeof()); }
     /** @return {@code put(0, b)} */
     public BytePointer put(byte b) { return put(0, b); }
     /**
@@ -258,7 +257,10 @@ public class BytePointer extends Pointer {
      * @param b the {@code byte} value to copy
      * @return this
      */
-    public native BytePointer put(long i, byte b);
+    public BytePointer put(long i, byte b) {
+        Raw.getInstance().putByte(address + i * sizeof(), b);
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public BytePointer get(byte[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/CLongPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/CLongPointer.java
@@ -82,7 +82,6 @@ public class CLongPointer extends Pointer {
     public CLongPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public CLongPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public CLongPointer position(long position) {
@@ -100,7 +99,7 @@ public class CLongPointer extends Pointer {
     /** @return {@code get(0)} */
     public long get() { return get(0); }
     /** @return the i-th {@code long} value of a native array */
-    @Cast("long") public native long get(long i);
+    @Cast("long") public long get(long i) { return Raw.getInstance().getCLong(address + i * sizeof()); }
     /** @return {@code put(0, l)} */
     public CLongPointer put(long l) { return put(0, l); }
     /**
@@ -110,7 +109,10 @@ public class CLongPointer extends Pointer {
      * @param l the {@code long} value to copy
      * @return this
      */
-    public native CLongPointer put(long i, long l);
+    public CLongPointer put(long i, long l) {
+        Raw.getInstance().putCLong(address + i * sizeof(), l);
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public CLongPointer get(long[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/CharPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/CharPointer.java
@@ -104,7 +104,6 @@ public class CharPointer extends Pointer {
     public CharPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public CharPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public CharPointer position(long position) {
@@ -166,7 +165,7 @@ public class CharPointer extends Pointer {
     /** @return {@code get(0)} */
     public char get() { return get(0); }
     /** @return the i-th {@code char} value of a native array */
-    public native char get(long i);
+    public char get(long i) { return Raw.getInstance().getChar(address + i * sizeof()); }
     /** @return {@code put(0, c)} */
     public CharPointer put(char c) { return put(0, c); }
     /**
@@ -176,7 +175,10 @@ public class CharPointer extends Pointer {
      * @param c the {@code char} value to copy
      * @return this
      */
-    public native CharPointer put(long i, char c);
+    public CharPointer put(long i, char c) {
+        Raw.getInstance().putChar(address + i * sizeof(), c);
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public CharPointer get(char[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/DoublePointer.java
+++ b/src/main/java/org/bytedeco/javacpp/DoublePointer.java
@@ -94,7 +94,6 @@ public class DoublePointer extends Pointer {
     public DoublePointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public DoublePointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public DoublePointer position(long position) {
@@ -115,7 +114,7 @@ public class DoublePointer extends Pointer {
     /** @return {@code get(0)} */
     public double get() { return get(0); }
     /** @return the i-th {@code double} value of a native array */
-    public native double get(long i);
+    public double get(long i) { return Raw.getInstance().getDouble(address + i * sizeof()); }
     /** @return {@code put(0, d)} */
     public DoublePointer put(double d) { return put(0, d); }
     /**
@@ -125,7 +124,10 @@ public class DoublePointer extends Pointer {
      * @param d the {@code double} value to copy
      * @return this
      */
-    public native DoublePointer put(long i, double d);
+    public DoublePointer put(long i, double d) {
+        Raw.getInstance().putDouble(address + i * sizeof(), d);
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public DoublePointer get(double[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/FloatPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/FloatPointer.java
@@ -94,7 +94,6 @@ public class FloatPointer extends Pointer {
     public FloatPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public FloatPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public FloatPointer position(long position) {
@@ -115,7 +114,7 @@ public class FloatPointer extends Pointer {
     /** @return {@code get(0)} */
     public float get() { return get(0); }
     /** @return the i-th {@code float} value of a native array */
-    public native float get(long i);
+    public float get(long i) { return Raw.getInstance().getFloat(address + i * sizeof()); }
     /** @return {@code put(0, f)} */
     public FloatPointer put(float f) { return put(0, f); }
     /**
@@ -125,7 +124,10 @@ public class FloatPointer extends Pointer {
      * @param f the {@code float} value to copy
      * @return this
      */
-    public native FloatPointer put(long i, float f);
+    public FloatPointer put(long i, float f) {
+        Raw.getInstance().putFloat(address + i * sizeof(), f);
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public FloatPointer get(float[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/IntPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/IntPointer.java
@@ -104,7 +104,6 @@ public class IntPointer extends Pointer {
     public IntPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public IntPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public IntPointer position(long position) {
@@ -170,7 +169,7 @@ public class IntPointer extends Pointer {
     /** @return {@code get(0)} */
     public int get() { return get(0); }
     /** @return the i-th {@code int} value of a native array */
-    public native int get(long i);
+    public int get(long i) { return Raw.getInstance().getInt(address + i * sizeof()); }
     /** @return {@code put(0, j)} */
     public IntPointer put(int j) { return put(0, j); }
     /**
@@ -180,7 +179,10 @@ public class IntPointer extends Pointer {
      * @param j the {@code int} value to copy
      * @return this
      */
-    public native IntPointer put(long i, int j);
+    public IntPointer put(long i, int j) {
+        Raw.getInstance().putInt(address + i * sizeof(), j);
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public IntPointer get(int[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/LongPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/LongPointer.java
@@ -94,7 +94,6 @@ public class LongPointer extends Pointer {
     public LongPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public LongPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public LongPointer position(long position) {

--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -110,6 +110,10 @@ public class Pointer implements AutoCloseable {
     }
     private native void allocate(Buffer b);
 
+    protected void allocateArray(long size) {
+        this.address = Raw.getInstance().allocateMemory(size * sizeof());
+    }
+
     /**
      * Called by native libraries to initialize the object fields.
      *

--- a/src/main/java/org/bytedeco/javacpp/PointerPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/PointerPointer.java
@@ -155,7 +155,6 @@ public class PointerPointer<P extends Pointer> extends Pointer {
     public PointerPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public PointerPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** This is just to keep references to Pointer objects and prevent premature deallocation. */
     private P[] pointerArray;

--- a/src/main/java/org/bytedeco/javacpp/Raw.java
+++ b/src/main/java/org/bytedeco/javacpp/Raw.java
@@ -19,7 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.bytedeco.javacpp.indexer;
+package org.bytedeco.javacpp;
 
 /**
  * The raw memory interface supporting long indexing.
@@ -41,6 +41,9 @@ abstract class Raw {
         return INSTANCE;
     }
 
+    abstract long allocateMemory(long capacity);
+    abstract void freeMemory(long address);
+
     abstract byte getByte(long address);
     abstract void putByte(long address, byte b);
     abstract short getShort(long address);
@@ -57,6 +60,12 @@ abstract class Raw {
     abstract void putChar(long address, char c);
     abstract boolean getBoolean(long address);
     abstract void putBoolean(long address, boolean b);
+    abstract boolean getBool(long address);
+    abstract void putBool(long address, boolean b);
+    abstract long getCLong(long address);
+    abstract void putCLong(long address, long l);
+    abstract long getSizeT(long address);
+    abstract void putSizeT(long address, long st);
 
     abstract byte getByte(byte[] array, long offset);
     abstract void putByte(byte[] array, long offset, byte b);

--- a/src/main/java/org/bytedeco/javacpp/ReverseUnsafeRaw.java
+++ b/src/main/java/org/bytedeco/javacpp/ReverseUnsafeRaw.java
@@ -19,7 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.bytedeco.javacpp.indexer;
+package org.bytedeco.javacpp;
 
 /**
  * A raw memory interface based on {@link UnsafeRaw} that swaps the bytes.

--- a/src/main/java/org/bytedeco/javacpp/ShortPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/ShortPointer.java
@@ -94,7 +94,6 @@ public class ShortPointer extends Pointer {
     public ShortPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public ShortPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public ShortPointer position(long position) {
@@ -115,7 +114,7 @@ public class ShortPointer extends Pointer {
     /** @return {@code get(0)} */
     public short get() { return get(0); }
     /** @return the i-th {@code short} value of a native array */
-    public native short get(long i);
+    public short get(long i) { return Raw.getInstance().getShort(address + i * sizeof()); }
     /** @return {@code put(0, s)} */
     public ShortPointer put(short s) { return put(0, s); }
     /**
@@ -125,7 +124,10 @@ public class ShortPointer extends Pointer {
      * @param s the {@code short} value to copy
      * @return this
      */
-    public native ShortPointer put(long i, short s);
+    public ShortPointer put(long i, short s) {
+        Raw.getInstance().putShort(address + i * sizeof(), s);
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public ShortPointer get(short[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/SizeTPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/SizeTPointer.java
@@ -81,7 +81,6 @@ public class SizeTPointer extends Pointer {
     public SizeTPointer() { }
     /** @see Pointer#Pointer(Pointer) */
     public SizeTPointer(Pointer p) { super(p); }
-    private native void allocateArray(long size);
 
     /** @see Pointer#position(long) */
     @Override public SizeTPointer position(long position) {
@@ -99,7 +98,7 @@ public class SizeTPointer extends Pointer {
     /** @return {@code get(0)} */
     public long get() { return get(0); }
     /** @return the i-th {@code size_t} value of a native array */
-    @Cast("size_t") public native long get(long i);
+    @Cast("size_t") public long get(long i) { return Raw.getInstance().getSizeT(address + i * sizeof()); }
     /** @return {@code put(0, s)} */
     public SizeTPointer put(long s) { return put(0, s); }
     /**
@@ -109,7 +108,10 @@ public class SizeTPointer extends Pointer {
      * @param s the {@code size_t} value to copy
      * @return this
      */
-    public native SizeTPointer put(long i, long s);
+    public SizeTPointer put(long i, long s) {
+        Raw.getInstance().putSizeT(address + i * sizeof(), s);
+        return this;
+    }
 
     /** @return {@code get(array, 0, array.length)} */
     public SizeTPointer get(long[] array) { return get(array, 0, array.length); }

--- a/src/main/java/org/bytedeco/javacpp/UnsafeRaw.java
+++ b/src/main/java/org/bytedeco/javacpp/UnsafeRaw.java
@@ -19,7 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.bytedeco.javacpp.indexer;
+package org.bytedeco.javacpp;
 
 import java.lang.reflect.Field;
 import sun.misc.Unsafe;
@@ -37,7 +37,7 @@ class UnsafeRaw extends Raw {
         Unsafe o;
         long offset;
         try {
-            Class c = Class.forName("sun.misc.Unsafe");
+            Class<?> c = Class.forName("sun.misc.Unsafe");
             Field f = c.getDeclaredField("theUnsafe");
             c.getDeclaredMethod("getByte", long.class);
             c.getDeclaredMethod("getShort", long.class);
@@ -61,6 +61,9 @@ class UnsafeRaw extends Raw {
 
     static boolean isAvailable() { return UNSAFE != null; }
 
+    @Override long allocateMemory(long capacity) { return UNSAFE.allocateMemory(capacity); }
+    @Override void freeMemory(long address) { UNSAFE.freeMemory(address); }
+
     @Override byte getByte(long address) { return UNSAFE.getByte(address); }
     @Override void putByte(long address, byte b) { UNSAFE.putByte(address, b); }
     @Override short getShort(long address) { return UNSAFE.getShort(address); }
@@ -77,6 +80,12 @@ class UnsafeRaw extends Raw {
     @Override void putChar(long address, char c) { UNSAFE.putChar(address, c); }
     @Override boolean getBoolean(long address) { return UNSAFE.getByte(address) != 0; }
     @Override void putBoolean(long address, boolean b) { UNSAFE.putByte(address, b ? (byte)1 : (byte)0); }
+    @Override boolean getBool(long address) { throw new UnsupportedOperationException(); }
+    @Override void putBool(long address, boolean b) { throw new UnsupportedOperationException(); }
+    @Override long getCLong(long address) { throw new UnsupportedOperationException(); }
+    @Override void putCLong(long address, long l) { throw new UnsupportedOperationException(); }
+    @Override long getSizeT(long address) { throw new UnsupportedOperationException(); }
+    @Override void putSizeT(long address, long st) { throw new UnsupportedOperationException(); }
 
     @Override byte getByte(byte[] array, long offset) { return UNSAFE.getByte(array, arrayOffset + offset); }
     @Override void putByte(byte[] array, long offset, byte b) { UNSAFE.putByte(array, arrayOffset + offset, b); }

--- a/src/main/java/org/bytedeco/javacpp/indexer/Bfloat16Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Bfloat16Indexer.java
@@ -23,6 +23,8 @@
 package org.bytedeco.javacpp.indexer;
 
 import java.nio.ShortBuffer;
+
+import org.bytedeco.javacpp.Raw;
 import org.bytedeco.javacpp.ShortPointer;
 
 /**

--- a/src/main/java/org/bytedeco/javacpp/indexer/Bfloat16RawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Bfloat16RawIndexer.java
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.ShortPointer;
 
 /**
- * An indexer for a {@link ShortPointer} using the {@link Raw} instance, treated as bfloat16.
+ * An indexer for a {@link ShortPointer}, treated as bfloat16.
  *
  * @author Samuel Audet
  */
 public class Bfloat16RawIndexer extends Bfloat16Indexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected ShortPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code Bfloat16RawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code Bfloat16RawIndexer(pointer, Index.create(pointer.limit()))}. */
     public Bfloat16RawIndexer(ShortPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code Bfloat16RawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class Bfloat16RawIndexer extends Bfloat16Indexer {
     public Bfloat16RawIndexer(ShortPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class Bfloat16RawIndexer extends Bfloat16Indexer {
         return new Bfloat16RawIndexer(pointer, index);
     }
 
-    public float getRaw(long i) {
-        return toFloat(RAW.getShort(base + checkIndex(i, size) * VALUE_BYTES));
-    }
     @Override public float get(long i) {
-        return getRaw(index(i));
+        return toFloat(pointer.get((int)index(i)));
     }
     @Override public Bfloat16Indexer get(long i, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            h[offset + n] = getRaw(index(i) + n);
+            h[offset + n] = toFloat(pointer.get((int)index(i) + n));
         }
         return this;
     }
     @Override public float get(long i, long j) {
-        return getRaw(index(i, j));
+        return toFloat(pointer.get((int)index(i, j)));
     }
     @Override public Bfloat16Indexer get(long i, long j, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            h[offset + n] = getRaw(index(i, j) + n);
+            h[offset + n] = toFloat(pointer.get((int)index(i, j) + n));
         }
         return this;
     }
     @Override public float get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return toFloat(pointer.get((int)index(i, j, k)));
     }
     @Override public float get(long... indices) {
-        return getRaw(index(indices));
+        return toFloat(pointer.get((int)index(indices)));
     }
     @Override public Bfloat16Indexer get(long[] indices, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            h[offset + n] = getRaw(index(indices) + n);
+            h[offset + n] = toFloat(pointer.get((int)index(indices) + n));
         }
         return this;
     }
 
-    public Bfloat16Indexer putRaw(long i, float h) {
-        RAW.putShort(base + checkIndex(i, size) * VALUE_BYTES, (short)fromFloat(h));
-        return this;
-    }
     @Override public Bfloat16Indexer put(long i, float h) {
-        return putRaw(index(i), h);
+        pointer.put((int)index(i), (short)fromFloat(h));
+        return this;
     }
     @Override public Bfloat16Indexer put(long i, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, h[offset + n]);
+            pointer.put((int)index(i) + n, (short)fromFloat(h[offset + n]));
         }
         return this;
     }
     @Override public Bfloat16Indexer put(long i, long j, float h) {
-        putRaw(index(i, j), h);
+        pointer.put((int)index(i, j), (short)fromFloat(h));
         return this;
     }
     @Override public Bfloat16Indexer put(long i, long j, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, h[offset + n]);
+            pointer.put((int)index(i, j) + n, (short)fromFloat(h[offset + n]));
         }
         return this;
     }
     @Override public Bfloat16Indexer put(long i, long j, long k, float h) {
-        putRaw(index(i, j, k), h);
+        pointer.put((int)index(i, j, k), (short)fromFloat(h));
         return this;
     }
     @Override public Bfloat16Indexer put(long[] indices, float h) {
-        putRaw(index(indices), h);
+        pointer.put((int)index(indices), (short)fromFloat(h));
         return this;
     }
     @Override public Bfloat16Indexer put(long[] indices, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, h[offset + n]);
+            pointer.put((int)index(indices) + n, (short)fromFloat(h[offset + n]));
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/BooleanIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/BooleanIndexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.ByteBuffer;
 import org.bytedeco.javacpp.BooleanPointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code boolean} primitive type.

--- a/src/main/java/org/bytedeco/javacpp/indexer/BooleanRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/BooleanRawIndexer.java
@@ -22,43 +22,37 @@
 
 package org.bytedeco.javacpp.indexer;
 
-import org.bytedeco.javacpp.BooleanPointer;
+import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for a {@link BooleanPointer} using the {@link Raw} instance.
+ * An indexer for a {@link BytePointer} as {@code boolean} values.
  *
  * @author Samuel Audet
  */
 public class BooleanRawIndexer extends BooleanIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
-    protected BooleanPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
+    protected BytePointer pointer;
 
-    /** Calls {@code BooleanRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
-    public BooleanRawIndexer(BooleanPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+    /** Calls {@code BooleanRawIndexer(pointer, Index.create(pointer.limit()))}. */
+    public BooleanRawIndexer(BytePointer pointer) {
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code BooleanRawIndexer(pointer, Index.create(sizes))}. */
-    public BooleanRawIndexer(BooleanPointer pointer, long... sizes) {
-        this(pointer, sizes, strides(sizes));
+    public BooleanRawIndexer(BytePointer pointer, long... sizes) {
+        this(pointer, Index.create(sizes));
     }
 
     /** Calls {@code BooleanRawIndexer(pointer, Index.create(sizes, strides))}. */
-    public BooleanRawIndexer(BooleanPointer pointer, long[] sizes, long[] strides) {
+    public BooleanRawIndexer(BytePointer pointer, long[] sizes, long[] strides) {
         this(pointer, Index.create(sizes, strides));
     }
 
     /** Constructor to set the {@link #pointer} and {@link #index}. */
-    public BooleanRawIndexer(BooleanPointer pointer, Index index) {
+    public BooleanRawIndexer(BytePointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class BooleanRawIndexer extends BooleanIndexer {
         return new BooleanRawIndexer(pointer, index);
     }
 
-    public boolean getRaw(long i) {
-        return RAW.getBoolean(base + checkIndex(i, size) * VALUE_BYTES);
-    }
     @Override public boolean get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i)) != 0;
     }
     @Override public BooleanIndexer get(long i, boolean[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(i) + n);
+            b[offset + n] = pointer.get((int)index(i) + n) != 0;
         }
         return this;
     }
     @Override public boolean get(long i, long j) {
-        return getRaw(index(i, j));
+        return pointer.get((int)index(i, j)) != 0;
     }
     @Override public BooleanIndexer get(long i, long j, boolean[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(i, j) + n);
+            b[offset + n] = pointer.get((int)index(i, j) + n) != 0;
         }
         return this;
     }
     @Override public boolean get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return pointer.get((int)index(i, j, k)) != 0;
     }
     @Override public boolean get(long... indices) {
-        return getRaw(index(indices));
+        return pointer.get((int)index(indices)) != 0;
     }
     @Override public BooleanIndexer get(long[] indices, boolean[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(indices) + n);
+            b[offset + n] = pointer.get((int)index(indices) + n) != 0;
         }
         return this;
     }
 
-    public BooleanIndexer putRaw(long i, boolean b) {
-        RAW.putBoolean(base + checkIndex(i, size) * VALUE_BYTES, b);
-        return this;
-    }
     @Override public BooleanIndexer put(long i, boolean b) {
-        return putRaw(index(i), b);
+        pointer.put((int)index(i), b ? (byte)1 : (byte)0);
+        return this;
     }
     @Override public BooleanIndexer put(long i, boolean[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, b[offset + n]);
+            pointer.put((int)index(i) + n, b[offset + n] ? (byte)1 : (byte)0);
         }
         return this;
     }
     @Override public BooleanIndexer put(long i, long j, boolean b) {
-        putRaw(index(i, j), b);
+        pointer.put((int)index(i, j), b ? (byte)1 : (byte)0);
         return this;
     }
     @Override public BooleanIndexer put(long i, long j, boolean[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, b[offset + n]);
+            pointer.put((int)index(i, j) + n, b[offset + n] ? (byte)1 : (byte)0);
         }
         return this;
     }
     @Override public BooleanIndexer put(long i, long j, long k, boolean b) {
-        putRaw(index(i, j, k), b);
+        pointer.put((int)index(i, j, k), b ? (byte)1 : (byte)0);
         return this;
     }
     @Override public BooleanIndexer put(long[] indices, boolean b) {
-        putRaw(index(indices), b);
+        pointer.put((int)index(indices), b ? (byte)1 : (byte)0);
         return this;
     }
     @Override public BooleanIndexer put(long[] indices, boolean[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, b[offset + n]);
+            pointer.put((int)index(indices) + n, b[offset + n] ? (byte)1 : (byte)0);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/ByteArrayIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/ByteArrayIndexer.java
@@ -22,6 +22,8 @@
 
 package org.bytedeco.javacpp.indexer;
 
+import org.bytedeco.javacpp.Raw;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 

--- a/src/main/java/org/bytedeco/javacpp/indexer/ByteIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/ByteIndexer.java
@@ -25,6 +25,7 @@ package org.bytedeco.javacpp.indexer;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code byte} primitive type.

--- a/src/main/java/org/bytedeco/javacpp/indexer/ByteRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/ByteRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2014-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -26,26 +26,22 @@ import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for a {@link BytePointer} using the {@link Raw} instance.
+ * An indexer for a {@link BytePointer}.
  *
  * @author Samuel Audet
  */
 public class ByteRawIndexer extends ByteIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected BytePointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code ByteRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code ByteRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public ByteRawIndexer(BytePointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code ByteRawIndexer(pointer, Index.create(sizes))}. */
     public ByteRawIndexer(BytePointer pointer, long... sizes) {
-        this(pointer, sizes, strides(sizes));
+        this(pointer, Index.create(sizes));
     }
 
     /** Calls {@code ByteRawIndexer(pointer, Index.create(sizes, strides))}. */
@@ -57,8 +53,6 @@ public class ByteRawIndexer extends ByteIndexer {
     public ByteRawIndexer(BytePointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position();
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,131 +63,125 @@ public class ByteRawIndexer extends ByteIndexer {
         return new ByteRawIndexer(pointer, index);
     }
 
-    public byte getRaw(long i) {
-        return RAW.getByte(base + checkIndex(i, size));
-    }
     @Override public byte get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i));
     }
     @Override public ByteIndexer get(long i, byte[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(i) + n);
+            b[offset + n] = pointer.get((int)index(i) + n);
         }
         return this;
     }
     @Override public byte get(long i, long j) {
-        return getRaw(index(i, j));
+        return pointer.get((int)index(i, j));
     }
     @Override public ByteIndexer get(long i, long j, byte[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(i, j) + n);
+            b[offset + n] = pointer.get((int)index(i, j) + n);
         }
         return this;
     }
     @Override public byte get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return pointer.get((int)index(i, j, k));
     }
     @Override public byte get(long... indices) {
-        return getRaw(index(indices));
+        return pointer.get((int)index(indices));
     }
     @Override public ByteIndexer get(long[] indices, byte[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(indices) + n);
+            b[offset + n] = pointer.get((int)index(indices) + n);
         }
         return this;
     }
 
-    public ByteIndexer putRaw(long i, byte b) {
-        RAW.putByte(base + checkIndex(i, size), b);
-        return this;
-    }
     @Override public ByteIndexer put(long i, byte b) {
-        return putRaw(index(i), b);
+        pointer.put((int)index(i), b);
+        return this;
     }
     @Override public ByteIndexer put(long i, byte[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, b[offset + n]);
+            pointer.put((int)index(i) + n, b[offset + n]);
         }
         return this;
     }
     @Override public ByteIndexer put(long i, long j, byte b) {
-        putRaw(index(i, j), b);
+        pointer.put((int)index(i, j), b);
         return this;
     }
     @Override public ByteIndexer put(long i, long j, byte[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, b[offset + n]);
+            pointer.put((int)index(i, j) + n, b[offset + n]);
         }
         return this;
     }
     @Override public ByteIndexer put(long i, long j, long k, byte b) {
-        putRaw(index(i, j, k), b);
+        pointer.put((int)index(i, j, k), b);
         return this;
     }
     @Override public ByteIndexer put(long[] indices, byte b) {
-        putRaw(index(indices), b);
+        pointer.put((int)index(indices), b);
         return this;
     }
     @Override public ByteIndexer put(long[] indices, byte[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, b[offset + n]);
+            pointer.put((int)index(indices) + n, b[offset + n]);
         }
         return this;
     }
 
     @Override public byte getByte(long i) {
-        return RAW.getByte(base + checkIndex(i, size - 1));
+        return pointer.get((int)i);
     }
     @Override public ByteIndexer putByte(long i, byte b) {
-        RAW.putByte(base + checkIndex(i, size - 1), b);
+        pointer.put((int)i, b);
         return this;
     }
 
     @Override public short getShort(long i) {
-        return RAW.getShort(base + checkIndex(i, size - 1));
+        return pointer.getShort((int)i);
     }
     @Override public ByteIndexer putShort(long i, short s) {
-        RAW.putShort(base + checkIndex(i, size - 1), s);
+        pointer.putShort((int)i, s);
         return this;
     }
 
     @Override public int getInt(long i) {
-        return RAW.getInt(base + checkIndex(i, size - 3));
+        return pointer.getInt((int)i);
     }
     @Override public ByteIndexer putInt(long i, int j) {
-        RAW.putInt(base + checkIndex(i, size - 3), j);
+        pointer.putInt((int)i, j);
         return this;
     }
 
     @Override public long getLong(long i) {
-        return RAW.getLong(base + checkIndex(i, size - 7));
+        return pointer.getLong((int)i);
     }
     @Override public ByteIndexer putLong(long i, long j) {
-        RAW.putLong(base + checkIndex(i, size - 7), j);
+        pointer.putLong((int)i, j);
         return this;
     }
 
     @Override public float getFloat(long i) {
-        return RAW.getFloat(base + checkIndex(i, size - 3));
+        return pointer.getFloat((int)i);
     }
     @Override public ByteIndexer putFloat(long i, float f) {
-        RAW.putFloat(base + checkIndex(i, size - 3), f);
+        pointer.putFloat((int)i, f);
         return this;
     }
 
     @Override public double getDouble(long i) {
-        return RAW.getDouble(base + checkIndex(i, size - 7));
+        return pointer.getDouble((int)i);
     }
     @Override public ByteIndexer putDouble(long i, double d) {
-        RAW.putDouble(base + checkIndex(i, size - 7), d);
+        pointer.putDouble((int)i, d);
         return this;
     }
 
     @Override public char getChar(long i) {
-        return RAW.getChar(base + checkIndex(i, size - 1));
+        return pointer.getChar((int)i);
     }
     @Override public ByteIndexer putChar(long i, char c) {
-        RAW.putChar(base + checkIndex(i, size - 1), c);
+        pointer.putChar((int)i, c);
         return this;
     }
 

--- a/src/main/java/org/bytedeco/javacpp/indexer/CharIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/CharIndexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.CharBuffer;
 import org.bytedeco.javacpp.CharPointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code char} primitive type.

--- a/src/main/java/org/bytedeco/javacpp/indexer/CharRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/CharRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2014-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.CharPointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for a {@link CharPointer} using the {@link Raw} instance.
+ * An indexer for a {@link CharPointer}.
  *
  * @author Samuel Audet
  */
 public class CharRawIndexer extends CharIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected CharPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code CharRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code CharRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public CharRawIndexer(CharPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code CharRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class CharRawIndexer extends CharIndexer {
     public CharRawIndexer(CharPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class CharRawIndexer extends CharIndexer {
         return new CharRawIndexer(pointer, index);
     }
 
-    public char getRaw(long i) {
-        return RAW.getChar(base + checkIndex(i, size) * VALUE_BYTES);
-    }
     @Override public char get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i));
     }
     @Override public CharIndexer get(long i, char[] c, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            c[offset + n] = getRaw(index(i) + n);
+            c[offset + n] = pointer.get((int)index(i) + n);
         }
         return this;
     }
     @Override public char get(long i, long j) {
-        return getRaw(index(i, j));
+        return pointer.get((int)index(i, j));
     }
     @Override public CharIndexer get(long i, long j, char[] c, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            c[offset + n] = getRaw(index(i, j) + n);
+            c[offset + n] = pointer.get((int)index(i, j) + n);
         }
         return this;
     }
     @Override public char get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return pointer.get((int)index(i, j, k));
     }
     @Override public char get(long... indices) {
-        return getRaw(index(indices));
+        return pointer.get((int)index(indices));
     }
     @Override public CharIndexer get(long[] indices, char[] c, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            c[offset + n] = getRaw(index(indices) + n);
+            c[offset + n] = pointer.get((int)index(indices) + n);
         }
         return this;
     }
 
-    public CharIndexer putRaw(long i, char c) {
-        RAW.putChar(base + checkIndex(i, size) * VALUE_BYTES, c);
-        return this;
-    }
     @Override public CharIndexer put(long i, char c) {
-        return putRaw(index(i), c);
+        pointer.put((int)index(i), c);
+        return this;
     }
     @Override public CharIndexer put(long i, char[] c, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, c[offset + n]);
+            pointer.put((int)index(i) + n, c[offset + n]);
         }
         return this;
     }
     @Override public CharIndexer put(long i, long j, char c) {
-        putRaw(index(i, j), c);
+        pointer.put((int)index(i, j), c);
         return this;
     }
     @Override public CharIndexer put(long i, long j, char[] c, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, c[offset + n]);
+            pointer.put((int)index(i, j) + n, c[offset + n]);
         }
         return this;
     }
     @Override public CharIndexer put(long i, long j, long k, char c) {
-        putRaw(index(i, j, k), c);
+        pointer.put((int)index(i, j, k), c);
         return this;
     }
     @Override public CharIndexer put(long[] indices, char c) {
-        putRaw(index(indices), c);
+        pointer.put((int)index(indices), c);
         return this;
     }
     @Override public CharIndexer put(long[] indices, char[] c, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, c[offset + n]);
+            pointer.put((int)index(indices) + n, c[offset + n]);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/DoubleIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/DoubleIndexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.DoubleBuffer;
 import org.bytedeco.javacpp.DoublePointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code double} primitive type.

--- a/src/main/java/org/bytedeco/javacpp/indexer/DoubleRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/DoubleRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2014-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.DoublePointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for a {@link DoublePointer} using the {@link Raw} instance.
+ * An indexer for a {@link DoublePointer}.
  *
  * @author Samuel Audet
  */
 public class DoubleRawIndexer extends DoubleIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected DoublePointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code DoubleRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code DoubleRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public DoubleRawIndexer(DoublePointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code DoubleRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class DoubleRawIndexer extends DoubleIndexer {
     public DoubleRawIndexer(DoublePointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class DoubleRawIndexer extends DoubleIndexer {
         return new DoubleRawIndexer(pointer, index);
     }
 
-    public double getRaw(long i) {
-        return RAW.getDouble(base + checkIndex(i, size) * VALUE_BYTES);
-    }
     @Override public double get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i));
     }
     @Override public DoubleIndexer get(long i, double[] d, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            d[offset + n] = getRaw(index(i) + n);
+            d[offset + n] = pointer.get((int)index(i) + n);
         }
         return this;
     }
     @Override public double get(long i, long j) {
-        return getRaw(index(i, j));
+        return pointer.get((int)index(i, j));
     }
     @Override public DoubleIndexer get(long i, long j, double[] d, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            d[offset + n] = getRaw(index(i, j) + n);
+            d[offset + n] = pointer.get((int)index(i, j) + n);
         }
         return this;
     }
     @Override public double get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return pointer.get((int)index(i, j, k));
     }
     @Override public double get(long... indices) {
-        return getRaw(index(indices));
+        return pointer.get((int)index(indices));
     }
     @Override public DoubleIndexer get(long[] indices, double[] d, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            d[offset + n] = getRaw(index(indices) + n);
+            d[offset + n] = pointer.get((int)index(indices) + n);
         }
         return this;
     }
 
-    public DoubleIndexer putRaw(long i, double d) {
-        RAW.putDouble(base + checkIndex(i, size) * VALUE_BYTES, d);
-        return this;
-    }
     @Override public DoubleIndexer put(long i, double d) {
-        return putRaw(index(i), d);
+        pointer.put((int)index(i), d);
+        return this;
     }
     @Override public DoubleIndexer put(long i, double[] d, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, d[offset + n]);
+            pointer.put((int)index(i) + n, d[offset + n]);
         }
         return this;
     }
     @Override public DoubleIndexer put(long i, long j, double d) {
-        putRaw(index(i, j), d);
+        pointer.put((int)index(i, j), d);
         return this;
     }
     @Override public DoubleIndexer put(long i, long j, double[] d, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, d[offset + n]);
+            pointer.put((int)index(i, j) + n, d[offset + n]);
         }
         return this;
     }
     @Override public DoubleIndexer put(long i, long j, long k, double d) {
-        putRaw(index(i, j, k), d);
+        pointer.put((int)index(i, j, k), d);
         return this;
     }
     @Override public DoubleIndexer put(long[] indices, double d) {
-        putRaw(index(indices), d);
+        pointer.put((int)index(indices), d);
         return this;
     }
     @Override public DoubleIndexer put(long[] indices, double[] d, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, d[offset + n]);
+            pointer.put((int)index(indices) + n, d[offset + n]);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/FloatIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/FloatIndexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.FloatBuffer;
 import org.bytedeco.javacpp.FloatPointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code float} primitive type.

--- a/src/main/java/org/bytedeco/javacpp/indexer/FloatRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/FloatRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2014-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -25,22 +25,19 @@ package org.bytedeco.javacpp.indexer;
 import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.javacpp.Pointer;
 
+
 /**
- * An indexer for a {@link FloatPointer} using the {@link Raw} instance.
+ * An indexer for a {@link FloatPointer}.
  *
  * @author Samuel Audet
  */
 public class FloatRawIndexer extends FloatIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected FloatPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code FloatRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code FloatRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public FloatRawIndexer(FloatPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code FloatRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +54,6 @@ public class FloatRawIndexer extends FloatIndexer {
     public FloatRawIndexer(FloatPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +64,68 @@ public class FloatRawIndexer extends FloatIndexer {
         return new FloatRawIndexer(pointer, index);
     }
 
-    public float getRaw(long i) {
-        return RAW.getFloat(base + checkIndex(i, size) * VALUE_BYTES);
-    }
     @Override public float get(long i) {
-        return getRaw(index(i));
+        return pointer.get(index(i));
     }
     @Override public FloatIndexer get(long i, float[] f, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            f[offset + n] = getRaw(index(i) + n);
+            f[offset + n] = pointer.get(index(i) + n);
         }
         return this;
     }
     @Override public float get(long i, long j) {
-        return getRaw(index(i, j));
+        return pointer.get(index(i, j));
     }
     @Override public FloatIndexer get(long i, long j, float[] f, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            f[offset + n] = getRaw(index(i, j) + n);
+            f[offset + n] = pointer.get(index(i, j) + n);
         }
         return this;
     }
     @Override public float get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return pointer.get(index(i, j, k));
     }
     @Override public float get(long... indices) {
-        return getRaw(index(indices));
+        return pointer.get(index(indices));
     }
     @Override public FloatIndexer get(long[] indices, float[] f, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            f[offset + n] = getRaw(index(indices) + n);
+            f[offset + n] = pointer.get(index(indices) + n);
         }
         return this;
     }
 
-    public FloatIndexer putRaw(long i, float f) {
-        RAW.putFloat(base + checkIndex(i, size) * VALUE_BYTES, f);
-        return this;
-    }
     @Override public FloatIndexer put(long i, float f) {
-        return putRaw(index(i), f);
+        pointer.put(index(i), f);
+        return this;
     }
     @Override public FloatIndexer put(long i, float[] f, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, f[offset + n]);
+            pointer.put(index(i) + n, f[offset + n]);
         }
         return this;
     }
     @Override public FloatIndexer put(long i, long j, float f) {
-        putRaw(index(i, j), f);
+        pointer.put(index(i, j), f);
         return this;
     }
     @Override public FloatIndexer put(long i, long j, float[] f, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, f[offset + n]);
+            pointer.put(index(i, j) + n, f[offset + n]);
         }
         return this;
     }
     @Override public FloatIndexer put(long i, long j, long k, float f) {
-        putRaw(index(i, j, k), f);
+        pointer.put(index(i, j, k), f);
         return this;
     }
     @Override public FloatIndexer put(long[] indices, float f) {
-        putRaw(index(indices), f);
+        pointer.put(index(indices), f);
         return this;
     }
     @Override public FloatIndexer put(long[] indices, float[] f, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, f[offset + n]);
+            pointer.put(index(indices) + n, f[offset + n]);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/HalfIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/HalfIndexer.java
@@ -23,6 +23,8 @@
 package org.bytedeco.javacpp.indexer;
 
 import java.nio.ShortBuffer;
+
+import org.bytedeco.javacpp.Raw;
 import org.bytedeco.javacpp.ShortPointer;
 
 /**

--- a/src/main/java/org/bytedeco/javacpp/indexer/HalfRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/HalfRawIndexer.java
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.ShortPointer;
 
 /**
- * An indexer for a {@link ShortPointer} using the {@link Raw} instance, treated as half-precision float.
+ * An indexer for a {@link ShortPointer}, treated as half-precision float.
  *
  * @author Samuel Audet
  */
 public class HalfRawIndexer extends HalfIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected ShortPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code HalfRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code HalfRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public HalfRawIndexer(ShortPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code HalfRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class HalfRawIndexer extends HalfIndexer {
     public HalfRawIndexer(ShortPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class HalfRawIndexer extends HalfIndexer {
         return new HalfRawIndexer(pointer, index);
     }
 
-    public float getRaw(long i) {
-        return toFloat(RAW.getShort(base + checkIndex(i, size) * VALUE_BYTES));
-    }
     @Override public float get(long i) {
-        return getRaw(index(i));
+        return toFloat(pointer.get((int)index(i)));
     }
     @Override public HalfIndexer get(long i, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            h[offset + n] = getRaw(index(i) + n);
+            h[offset + n] = toFloat(pointer.get((int)index(i) + n));
         }
         return this;
     }
     @Override public float get(long i, long j) {
-        return getRaw(index(i, j));
+        return toFloat(pointer.get((int)index(i, j)));
     }
     @Override public HalfIndexer get(long i, long j, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            h[offset + n] = getRaw(index(i, j) + n);
+            h[offset + n] = toFloat(pointer.get((int)index(i, j) + n));
         }
         return this;
     }
     @Override public float get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return toFloat(pointer.get((int)index(i, j, k)));
     }
     @Override public float get(long... indices) {
-        return getRaw(index(indices));
+        return toFloat(pointer.get((int)index(indices)));
     }
     @Override public HalfIndexer get(long[] indices, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            h[offset + n] = getRaw(index(indices) + n);
+            h[offset + n] = toFloat(pointer.get((int)index(indices) + n));
         }
         return this;
     }
 
-    public HalfIndexer putRaw(long i, float h) {
-        RAW.putShort(base + checkIndex(i, size) * VALUE_BYTES, (short)fromFloat(h));
-        return this;
-    }
     @Override public HalfIndexer put(long i, float h) {
-        return putRaw(index(i), h);
+        pointer.put((int)index(i), (short)fromFloat(h));
+        return this;
     }
     @Override public HalfIndexer put(long i, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, h[offset + n]);
+            pointer.put((int)index(i) + n, (short)fromFloat(h[offset + n]));
         }
         return this;
     }
     @Override public HalfIndexer put(long i, long j, float h) {
-        putRaw(index(i, j), h);
+        pointer.put((int)index(i, j), (short)fromFloat(h));
         return this;
     }
     @Override public HalfIndexer put(long i, long j, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, h[offset + n]);
+            pointer.put((int)index(i, j) + n, (short)fromFloat(h[offset + n]));
         }
         return this;
     }
     @Override public HalfIndexer put(long i, long j, long k, float h) {
-        putRaw(index(i, j, k), h);
+        pointer.put((int)index(i, j, k), (short)fromFloat(h));
         return this;
     }
     @Override public HalfIndexer put(long[] indices, float h) {
-        putRaw(index(indices), h);
+        pointer.put((int)index(indices), (short)fromFloat(h));
         return this;
     }
     @Override public HalfIndexer put(long[] indices, float[] h, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, h[offset + n]);
+            pointer.put((int)index(indices) + n, (short)fromFloat(h[offset + n]));
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/Indexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.Buffer;
 import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Top-level class of all data indexers, providing easy-to-use and efficient

--- a/src/main/java/org/bytedeco/javacpp/indexer/IntIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/IntIndexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.IntBuffer;
 import org.bytedeco.javacpp.IntPointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code int} primitive type.

--- a/src/main/java/org/bytedeco/javacpp/indexer/IntRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/IntRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2014-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.IntPointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for an {@link IntPointer} using the {@link Raw} instance.
+ * An indexer for an {@link IntPointer}.
  *
  * @author Samuel Audet
  */
 public class IntRawIndexer extends IntIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected IntPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code IntRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code IntRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public IntRawIndexer(IntPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code IntRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class IntRawIndexer extends IntIndexer {
     public IntRawIndexer(IntPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class IntRawIndexer extends IntIndexer {
         return new IntRawIndexer(pointer, index);
     }
 
-    public int getRaw(long i) {
-        return RAW.getInt(base + checkIndex(i, size) * VALUE_BYTES);
-    }
     @Override public int get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i));
     }
     @Override public IntIndexer get(long i, int[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            m[offset + n] = getRaw(index(i) + n);
+            m[offset + n] = pointer.get((int)index(i) + n);
         }
         return this;
     }
     @Override public int get(long i, long j) {
-        return getRaw(index(i, j));
+        return pointer.get((int)index(i, j));
     }
     @Override public IntIndexer get(long i, long j, int[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            m[offset + n] = getRaw(index(i, j) + n);
+            m[offset + n] = pointer.get((int)index(i, j) + n);
         }
         return this;
     }
     @Override public int get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return pointer.get((int)index(i, j, k));
     }
     @Override public int get(long... indices) {
-        return getRaw(index(indices));
+        return pointer.get((int)index(indices));
     }
     @Override public IntIndexer get(long[] indices, int[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            m[offset + n] = getRaw(index(indices) + n);
+            m[offset + n] = pointer.get((int)index(indices) + n);
         }
         return this;
     }
 
-    public IntIndexer putRaw(long i, int n) {
-        RAW.putInt(base + checkIndex(i, size) * VALUE_BYTES, n);
-        return this;
-    }
     @Override public IntIndexer put(long i, int n) {
-        return putRaw(index(i), n);
+        pointer.put((int)index(i), n);
+        return this;
     }
     @Override public IntIndexer put(long i, int[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, m[offset + n]);
+            pointer.put((int)index(i) + n, m[offset + n]);
         }
         return this;
     }
     @Override public IntIndexer put(long i, long j, int n) {
-        putRaw(index(i, j), n);
+        pointer.put((int)index(i, j), n);
         return this;
     }
     @Override public IntIndexer put(long i, long j, int[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, m[offset + n]);
+            pointer.put((int)index(i, j) + n, m[offset + n]);
         }
         return this;
     }
     @Override public IntIndexer put(long i, long j, long k, int n) {
-        putRaw(index(i, j, k), n);
+        pointer.put((int)index(i, j, k), n);
         return this;
     }
     @Override public IntIndexer put(long[] indices, int n) {
-        putRaw(index(indices), n);
+        pointer.put((int)index(indices), n);
         return this;
     }
     @Override public IntIndexer put(long[] indices, int[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, m[offset + n]);
+            pointer.put((int)index(indices) + n, m[offset + n]);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/LongIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/LongIndexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.LongBuffer;
 import org.bytedeco.javacpp.LongPointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code long} primitive type.

--- a/src/main/java/org/bytedeco/javacpp/indexer/LongRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/LongRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2014-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.LongPointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for a {@link LongPointer} using the {@link Raw} instance.
+ * An indexer for a {@link LongPointer}.
  *
  * @author Samuel Audet
  */
 public class LongRawIndexer extends LongIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected LongPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code LongRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code LongRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public LongRawIndexer(LongPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code LongRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class LongRawIndexer extends LongIndexer {
     public LongRawIndexer(LongPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class LongRawIndexer extends LongIndexer {
         return new LongRawIndexer(pointer, index);
     }
 
-    public long getRaw(long i) {
-        return RAW.getLong(base + checkIndex(i, size) * VALUE_BYTES);
-    }
     @Override public long get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i));
     }
     @Override public LongIndexer get(long i, long[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            l[offset + n] = getRaw(index(i) + n);
+            l[offset + n] = pointer.get((int)index(i) + n);
         }
         return this;
     }
     @Override public long get(long i, long j) {
-        return getRaw(index(i, j));
+        return pointer.get((int)index(i, j));
     }
     @Override public LongIndexer get(long i, long j, long[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            l[offset + n] = getRaw(index(i, j) + n);
+            l[offset + n] = pointer.get((int)index(i, j) + n);
         }
         return this;
     }
     @Override public long get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return pointer.get((int)index(i, j, k));
     }
     @Override public long get(long... indices) {
-        return getRaw(index(indices));
+        return pointer.get((int)index(indices));
     }
     @Override public LongIndexer get(long[] indices, long[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            l[offset + n] = getRaw(index(indices) + n);
+            l[offset + n] = pointer.get((int)index(indices) + n);
         }
         return this;
     }
 
-    public LongIndexer putRaw(long i, long l) {
-        RAW.putLong(base + checkIndex(i, size) * VALUE_BYTES, l);
-        return this;
-    }
     @Override public LongIndexer put(long i, long l) {
-        return putRaw(index(i), l);
+        pointer.put((int)index(i), l);
+        return this;
     }
     @Override public LongIndexer put(long i, long[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, l[offset + n]);
+            pointer.put((int)index(i) + n, l[offset + n]);
         }
         return this;
     }
     @Override public LongIndexer put(long i, long j, long l) {
-        putRaw(index(i, j), l);
+        pointer.put((int)index(i, j), l);
         return this;
     }
     @Override public LongIndexer put(long i, long j, long[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, l[offset + n]);
+            pointer.put((int)index(i, j) + n, l[offset + n]);
         }
         return this;
     }
     @Override public LongIndexer put(long i, long j, long k, long l) {
-        putRaw(index(i, j, k), l);
+        pointer.put((int)index(i, j, k), l);
         return this;
     }
     @Override public LongIndexer put(long[] indices, long l) {
-        putRaw(index(indices), l);
+        pointer.put((int)index(indices), l);
         return this;
     }
     @Override public LongIndexer put(long[] indices, long[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, l[offset + n]);
+            pointer.put((int)index(indices) + n, l[offset + n]);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/ShortIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/ShortIndexer.java
@@ -23,6 +23,8 @@
 package org.bytedeco.javacpp.indexer;
 
 import java.nio.ShortBuffer;
+
+import org.bytedeco.javacpp.Raw;
 import org.bytedeco.javacpp.ShortPointer;
 
 /**

--- a/src/main/java/org/bytedeco/javacpp/indexer/ShortRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/ShortRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2014-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.ShortPointer;
 
 /**
- * An indexer for a {@link ShortPointer} using the {@link Raw} instance.
+ * An indexer for a {@link ShortPointer}.
  *
  * @author Samuel Audet
  */
 public class ShortRawIndexer extends ShortIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected ShortPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code ShortRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code ShortRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public ShortRawIndexer(ShortPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code ShortRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class ShortRawIndexer extends ShortIndexer {
     public ShortRawIndexer(ShortPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class ShortRawIndexer extends ShortIndexer {
         return new ShortRawIndexer(pointer, index);
     }
 
-    public short getRaw(long i) {
-        return RAW.getShort(base + checkIndex(i, size) * VALUE_BYTES);
-    }
     @Override public short get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i));
     }
     @Override public ShortIndexer get(long i, short[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            s[offset + n] = getRaw(index(i) + n);
+            s[offset + n] = pointer.get((int)index(i) + n);
         }
         return this;
     }
     @Override public short get(long i, long j) {
-        return getRaw(index(i, j));
+        return pointer.get((int)index(i, j));
     }
     @Override public ShortIndexer get(long i, long j, short[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            s[offset + n] = getRaw(index(i, j) + n);
+            s[offset + n] = pointer.get((int)index(i, j) + n);
         }
         return this;
     }
     @Override public short get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return pointer.get((int)index(i, j, k));
     }
     @Override public short get(long... indices) {
-        return getRaw(index(indices));
+        return pointer.get((int)index(indices));
     }
     @Override public ShortIndexer get(long[] indices, short[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            s[offset + n] = getRaw(index(indices) + n);
+            s[offset + n] = pointer.get((int)index(indices) + n);
         }
         return this;
     }
 
-    public ShortIndexer putRaw(long i, short s) {
-        RAW.putShort(base + checkIndex(i, size) * VALUE_BYTES, s);
-        return this;
-    }
     @Override public ShortIndexer put(long i, short s) {
-        return putRaw(index(i), s);
+        pointer.put((int)index(i), s);
+        return this;
     }
     @Override public ShortIndexer put(long i, short[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, s[offset + n]);
+            pointer.put((int)index(i) + n, s[offset + n]);
         }
         return this;
     }
     @Override public ShortIndexer put(long i, long j, short s) {
-        putRaw(index(i, j), s);
+        pointer.put((int)index(i, j), s);
         return this;
     }
     @Override public ShortIndexer put(long i, long j, short[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, s[offset + n]);
+            pointer.put((int)index(i, j) + n, s[offset + n]);
         }
         return this;
     }
     @Override public ShortIndexer put(long i, long j, long k, short s) {
-        putRaw(index(i, j, k), s);
+        pointer.put((int)index(i, j, k), s);
         return this;
     }
     @Override public ShortIndexer put(long[] indices, short s) {
-        putRaw(index(indices), s);
+        pointer.put((int)index(indices), s);
         return this;
     }
     @Override public ShortIndexer put(long[] indices, short[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, s[offset + n]);
+            pointer.put((int)index(indices) + n, s[offset + n]);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/UByteIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/UByteIndexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.ByteBuffer;
 import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code byte} primitive type, treated as unsigned.

--- a/src/main/java/org/bytedeco/javacpp/indexer/UByteRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/UByteRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2015-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -26,26 +26,22 @@ import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for a {@link BytePointer} using the {@link Raw} instance, treated as unsigned.
+ * An indexer for a {@link BytePointer}, treated as unsigned.
  *
  * @author Samuel Audet
  */
 public class UByteRawIndexer extends UByteIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected BytePointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code UByteRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code UByteRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public UByteRawIndexer(BytePointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code UByteRawIndexer(pointer, Index.create(sizes))}. */
     public UByteRawIndexer(BytePointer pointer, long... sizes) {
-        this(pointer, sizes, strides(sizes));
+        this(pointer, Index.create(sizes));
     }
 
     /** Calls {@code UByteRawIndexer(pointer, Index.create(sizes, strides))}. */
@@ -57,8 +53,6 @@ public class UByteRawIndexer extends UByteIndexer {
     public UByteRawIndexer(BytePointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position();
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,75 +63,68 @@ public class UByteRawIndexer extends UByteIndexer {
         return new UByteRawIndexer(pointer, index);
     }
 
-    public int getRaw(long i) {
-        return RAW.getByte(base + checkIndex(i, size)) & 0xFF;
-    }
     @Override public int get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i)) & 0xFF;
     }
     @Override public UByteIndexer get(long i, int[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(i) + n) & 0xFF;
+            b[offset + n] = pointer.get((int)index(i) + n) & 0xFF;
         }
         return this;
     }
     @Override public int get(long i, long j) {
-        return getRaw(index(i, j)) & 0xFF;
+        return pointer.get((int)index(i, j)) & 0xFF;
     }
     @Override public UByteIndexer get(long i, long j, int[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(i, j) + n) & 0xFF;
+            b[offset + n] = pointer.get((int)index(i, j) + n) & 0xFF;
         }
         return this;
     }
     @Override public int get(long i, long j, long k) {
-        return getRaw(index(i, j, k)) & 0xFF;
+        return pointer.get((int)index(i, j, k)) & 0xFF;
     }
     @Override public int get(long... indices) {
-        return getRaw(index(indices)) & 0xFF;
+        return pointer.get((int)index(indices)) & 0xFF;
     }
     @Override public UByteIndexer get(long[] indices, int[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            b[offset + n] = getRaw(index(indices) + n) & 0xFF;
+            b[offset + n] = pointer.get((int)index(indices) + n) & 0xFF;
         }
         return this;
     }
 
-    public UByteIndexer putRaw(long i, int b) {
-        RAW.putByte(base + checkIndex(i, size), (byte)b);
-        return this;
-    }
     @Override public UByteIndexer put(long i, int b) {
-        putRaw(index(i), b);
+        pointer.put((int)index(i), (byte)b);
         return this;
     }
     @Override public UByteIndexer put(long i, int[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, b[offset + n]);
+            pointer.put((int)index(i) + n, (byte)b[offset + n]);
         }
         return this;
     }
     @Override public UByteIndexer put(long i, long j, int b) {
-        putRaw(index(i, j), b);
+        pointer.put((int)index(i, j), (byte)b);
         return this;
     }
     @Override public UByteIndexer put(long i, long j, int[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, b[offset + n]);
+            pointer.put((int)index(i, j) + n, (byte)b[offset + n]);
         }
         return this;
     }
     @Override public UByteIndexer put(long i, long j, long k, int b) {
-        putRaw(index(i, j, k), b);
+        pointer.put((int)index(i, j, k), (byte)b);
         return this;
     }
     @Override public UByteIndexer put(long[] indices, int b) {
-        putRaw(index(indices), b);
+        pointer.put((int)index(indices), (byte)b);
         return this;
     }
     @Override public UByteIndexer put(long[] indices, int[] b, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, b[offset + n]);
+            pointer.put((int)index(indices) + n, (byte)b[offset + n]);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/UIntIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/UIntIndexer.java
@@ -24,6 +24,7 @@ package org.bytedeco.javacpp.indexer;
 
 import java.nio.IntBuffer;
 import org.bytedeco.javacpp.IntPointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code int} primitive type, treated as unsigned.

--- a/src/main/java/org/bytedeco/javacpp/indexer/UIntRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/UIntRawIndexer.java
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.IntPointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for a {@link IntPointer} using the {@link Raw} instance, treated as unsigned.
+ * An indexer for a {@link IntPointer}, treated as unsigned.
  *
  * @author Samuel Audet
  */
 public class UIntRawIndexer extends UIntIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected IntPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code UIntRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code UIntRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public UIntRawIndexer(IntPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code UIntRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class UIntRawIndexer extends UIntIndexer {
     public UIntRawIndexer(IntPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class UIntRawIndexer extends UIntIndexer {
         return new UIntRawIndexer(pointer, index);
     }
 
-    public long getRaw(long i) {
-        return RAW.getInt(base + checkIndex(i, size) * VALUE_BYTES) & 0xFFFFFFFFL;
-    }
     @Override public long get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i)) & 0xFFFFFFFFL;
     }
     @Override public UIntIndexer get(long i, long[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            m[offset + n] = getRaw(index(i) + n) & 0xFFFFFFFFL;
+            m[offset + n] = pointer.get((int)index(i) + n) & 0xFFFFFFFFL;
         }
         return this;
     }
     @Override public long get(long i, long j) {
-        return getRaw(index(i, j)) & 0xFFFFFFFFL;
+        return pointer.get((int)index(i, j)) & 0xFFFFFFFFL;
     }
     @Override public UIntIndexer get(long i, long j, long[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            m[offset + n] = getRaw(index(i, j) + n) & 0xFFFFFFFFL;
+            m[offset + n] = pointer.get((int)index(i, j) + n) & 0xFFFFFFFFL;
         }
         return this;
     }
     @Override public long get(long i, long j, long k) {
-        return getRaw(index(i, j, k)) & 0xFFFFFFFFL;
+        return pointer.get((int)index(i, j, k)) & 0xFFFFFFFFL;
     }
     @Override public long get(long... indices) {
-        return getRaw(index(indices)) & 0xFFFFFFFFL;
+        return pointer.get((int)index(indices)) & 0xFFFFFFFFL;
     }
     @Override public UIntIndexer get(long[] indices, long[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            m[offset + n] = getRaw(index(indices) + n) & 0xFFFFFFFFL;
+            m[offset + n] = pointer.get((int)index(indices) + n) & 0xFFFFFFFFL;
         }
         return this;
     }
 
-    public UIntIndexer putRaw(long i, long n) {
-        RAW.putInt(base + checkIndex(i, size) * VALUE_BYTES, (int)n);
-        return this;
-    }
     @Override public UIntIndexer put(long i, long n) {
-        return putRaw(index(i), n);
+        pointer.put((int)index(i), (int)n);
+        return this;
     }
     @Override public UIntIndexer put(long i, long[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, m[offset + n]);
+            pointer.put((int)index(i) + n, (int)m[offset + n]);
         }
         return this;
     }
     @Override public UIntIndexer put(long i, long j, long n) {
-        putRaw(index(i, j), n);
+        pointer.put((int)index(i, j), (int)n);
         return this;
     }
     @Override public UIntIndexer put(long i, long j, long[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, m[offset + n]);
+            pointer.put((int)index(i, j) + n, (int)m[offset + n]);
         }
         return this;
     }
     @Override public UIntIndexer put(long i, long j, long k, long n) {
-        putRaw(index(i, j, k), n);
+        pointer.put((int)index(i, j, k), (int)n);
         return this;
     }
     @Override public UIntIndexer put(long[] indices, long n) {
-        putRaw(index(indices), n);
+        pointer.put((int)index(indices), (int)n);
         return this;
     }
     @Override public UIntIndexer put(long[] indices, long[] m, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, m[offset + n]);
+            pointer.put((int)index(indices) + n, (int)m[offset + n]);
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/ULongIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/ULongIndexer.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.LongBuffer;
 import org.bytedeco.javacpp.LongPointer;
+import org.bytedeco.javacpp.Raw;
 
 /**
  * Abstract indexer for the {@code long} primitive type, treated as unsigned.

--- a/src/main/java/org/bytedeco/javacpp/indexer/ULongRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/ULongRawIndexer.java
@@ -27,21 +27,17 @@ import org.bytedeco.javacpp.LongPointer;
 import org.bytedeco.javacpp.Pointer;
 
 /**
- * An indexer for a {@link LongPointer} using the {@link Raw} instance, treated as unsigned.
+ * An indexer for a {@link LongPointer}, treated as unsigned.
  *
  * @author Samuel Audet
  */
 public class ULongRawIndexer extends ULongIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected LongPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code ULongRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code ULongRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public ULongRawIndexer(LongPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code ULongRawIndexer(pointer, Index.create(sizes))}. */
@@ -58,8 +54,6 @@ public class ULongRawIndexer extends ULongIndexer {
     public ULongRawIndexer(LongPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -70,74 +64,68 @@ public class ULongRawIndexer extends ULongIndexer {
         return new ULongRawIndexer(pointer, index);
     }
 
-    public BigInteger getRaw(long i) {
-        return toBigInteger(RAW.getLong(base + checkIndex(i, size) * VALUE_BYTES));
-    }
     @Override public BigInteger get(long i) {
-        return getRaw(index(i));
+        return toBigInteger(pointer.get((int)index(i)));
     }
     @Override public ULongIndexer get(long i, BigInteger[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            l[offset + n] = getRaw(index(i) + n);
+            l[offset + n] = toBigInteger(pointer.get((int)index(i) + n));
         }
         return this;
     }
     @Override public BigInteger get(long i, long j) {
-        return getRaw(index(i, j));
+        return toBigInteger(pointer.get((int)index(i, j)));
     }
     @Override public ULongIndexer get(long i, long j, BigInteger[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            l[offset + n] = getRaw(index(i, j) + n);
+            l[offset + n] = toBigInteger(pointer.get((int)index(i, j) + n));
         }
         return this;
     }
     @Override public BigInteger get(long i, long j, long k) {
-        return getRaw(index(i, j, k));
+        return toBigInteger(pointer.get((int)index(i, j, k)));
     }
     @Override public BigInteger get(long... indices) {
-        return getRaw(index(indices));
+        return toBigInteger(pointer.get((int)index(indices)));
     }
     @Override public ULongIndexer get(long[] indices, BigInteger[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            l[offset + n] = getRaw(index(indices) + n);
+            l[offset + n] = toBigInteger(pointer.get((int)index(indices) + n));
         }
         return this;
     }
 
-    public ULongIndexer putRaw(long i, BigInteger l) {
-        RAW.putLong(base + checkIndex(i, size) * VALUE_BYTES, fromBigInteger(l));
-        return this;
-    }
     @Override public ULongIndexer put(long i, BigInteger l) {
-        return putRaw(index(i), l);
+        pointer.put((int)index(i), fromBigInteger(l));
+        return this;
     }
     @Override public ULongIndexer put(long i, BigInteger[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, l[offset + n]);
+            pointer.put((int)index(i) + n, fromBigInteger(l[offset + n]));
         }
         return this;
     }
     @Override public ULongIndexer put(long i, long j, BigInteger l) {
-        putRaw(index(i, j), l);
+        pointer.put((int)index(i, j), fromBigInteger(l));
         return this;
     }
     @Override public ULongIndexer put(long i, long j, BigInteger[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, l[offset + n]);
+            pointer.put((int)index(i, j) + n, fromBigInteger(l[offset + n]));
         }
         return this;
     }
     @Override public ULongIndexer put(long i, long j, long k, BigInteger l) {
-        putRaw(index(i, j, k), l);
+        pointer.put((int)index(i, j, k), fromBigInteger(l));
         return this;
     }
     @Override public ULongIndexer put(long[] indices, BigInteger l) {
-        putRaw(index(indices), l);
+        pointer.put((int)index(indices), fromBigInteger(l));
         return this;
     }
     @Override public ULongIndexer put(long[] indices, BigInteger[] l, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, l[offset + n]);
+            pointer.put((int)index(indices) + n, fromBigInteger(l[offset + n]));
         }
         return this;
     }

--- a/src/main/java/org/bytedeco/javacpp/indexer/UShortIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/UShortIndexer.java
@@ -23,6 +23,8 @@
 package org.bytedeco.javacpp.indexer;
 
 import java.nio.ShortBuffer;
+
+import org.bytedeco.javacpp.Raw;
 import org.bytedeco.javacpp.ShortPointer;
 
 /**

--- a/src/main/java/org/bytedeco/javacpp/indexer/UShortRawIndexer.java
+++ b/src/main/java/org/bytedeco/javacpp/indexer/UShortRawIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Samuel Audet
+ * Copyright (C) 2015-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -26,21 +26,17 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.ShortPointer;
 
 /**
- * An indexer for a {@link ShortPointer} using the {@link Raw} instance, treated as unsigned.
+ * An indexer for a {@link ShortPointer}, treated as unsigned.
  *
  * @author Samuel Audet
  */
 public class UShortRawIndexer extends UShortIndexer {
-    /** The instance for the raw memory interface. */
-    protected static final Raw RAW = Raw.getInstance();
     /** The backing pointer. */
     protected ShortPointer pointer;
-    /** Base address and number of elements accessible. */
-    final long base, size;
 
-    /** Calls {@code UShortRawIndexer(pointer, Index.create(pointer.limit() - pointer.position()))}. */
+    /** Calls {@code UShortRawIndexer(pointer, Index.create(pointer.limit()))}. */
     public UShortRawIndexer(ShortPointer pointer) {
-        this(pointer, Index.create(pointer.limit() - pointer.position()));
+        this(pointer, Index.create(pointer.limit()));
     }
 
     /** Calls {@code UShortRawIndexer(pointer, Index.create(sizes))}. */
@@ -57,8 +53,6 @@ public class UShortRawIndexer extends UShortIndexer {
     public UShortRawIndexer(ShortPointer pointer, Index index) {
         super(index);
         this.pointer = pointer;
-        this.base = pointer.address() + pointer.position() * VALUE_BYTES;
-        this.size = pointer.limit() - pointer.position();
     }
 
     @Override public Pointer pointer() {
@@ -69,74 +63,68 @@ public class UShortRawIndexer extends UShortIndexer {
         return new UShortRawIndexer(pointer, index);
     }
 
-    public int getRaw(long i) {
-        return RAW.getShort(base + checkIndex(i, size) * VALUE_BYTES) & 0xFFFF;
-    }
     @Override public int get(long i) {
-        return getRaw(index(i));
+        return pointer.get((int)index(i)) & 0xFFFF;
     }
     @Override public UShortIndexer get(long i, int[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            s[offset + n] = getRaw(index(i) + n) & 0xFFFF;
+            s[offset + n] = pointer.get((int)index(i) + n) & 0xFFFF;
         }
         return this;
     }
     @Override public int get(long i, long j) {
-        return getRaw(index(i, j)) & 0xFFFF;
+        return pointer.get((int)index(i, j)) & 0xFFFF;
     }
     @Override public UShortIndexer get(long i, long j, int[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            s[offset + n] = getRaw(index(i, j) + n) & 0xFFFF;
+            s[offset + n] = pointer.get((int)index(i, j) + n) & 0xFFFF;
         }
         return this;
     }
     @Override public int get(long i, long j, long k) {
-        return getRaw(index(i, j, k)) & 0xFFFF;
+        return pointer.get((int)index(i, j, k)) & 0xFFFF;
     }
     @Override public int get(long... indices) {
-        return getRaw(index(indices)) & 0xFFFF;
+        return pointer.get((int)index(indices)) & 0xFFFF;
     }
     @Override public UShortIndexer get(long[] indices, int[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            s[offset + n] = getRaw(index(indices) + n) & 0xFFFF;
+            s[offset + n] = pointer.get((int)index(indices) + n) & 0xFFFF;
         }
         return this;
     }
 
-    public UShortIndexer putRaw(long i, int s) {
-        RAW.putShort(base + checkIndex(i, size) * VALUE_BYTES, (short)s);
-        return this;
-    }
     @Override public UShortIndexer put(long i, int s) {
-        return putRaw(index(i), s);
+        pointer.put((int)index(i), (short)s);
+        return this;
     }
     @Override public UShortIndexer put(long i, int[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i) + n, s[offset + n]);
+            pointer.put((int)index(i) + n, (short)s[offset + n]);
         }
         return this;
     }
     @Override public UShortIndexer put(long i, long j, int s) {
-        putRaw(index(i, j), s);
+        pointer.put((int)index(i, j), (short)s);
         return this;
     }
     @Override public UShortIndexer put(long i, long j, int[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(i, j) + n, s[offset + n]);
+            pointer.put((int)index(i, j) + n, (short)s[offset + n]);
         }
         return this;
     }
     @Override public UShortIndexer put(long i, long j, long k, int s) {
-        putRaw(index(i, j, k), s);
+        pointer.put((int)index(i, j, k), (short)s);
         return this;
     }
     @Override public UShortIndexer put(long[] indices, int s) {
-        putRaw(index(indices), s);
+        pointer.put((int)index(indices), (short)s);
         return this;
     }
     @Override public UShortIndexer put(long[] indices, int[] s, int offset, int length) {
         for (int n = 0; n < length; n++) {
-            putRaw(index(indices) + n, s[offset + n]);
+            pointer.put((int)index(indices) + n, (short)s[offset + n]);
         }
         return this;
     }


### PR DESCRIPTION
`sun.misc.Unsafe` is used in raw indexer, but it should be really used in Pointers: the indexers are just a layer on top of array/buffer/pointers.

Still unfinished as it is not clear how to handle bool, clong, size_t pointers.