### PR TITLE
Add support for static libraries with RoboVM

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -1239,6 +1239,12 @@ public class Loader {
             }
         }
 
+        if (properties.getProperty("platform").startsWith("ios") 
+        && Boolean.parseBoolean(properties.getProperty("platform.library.static", "false"))) {
+            Loader.robovmOnLoad();
+            return "roboVMstaticLib";
+        }
+
         String executable = p.getProperty("platform.executable");
         if (executable != null && executable.length() > 0) {
             String platform = p.getProperty("platform");
@@ -1910,4 +1916,7 @@ public class Loader {
 
     /** Returns the JavaVM JNI object, as required by some APIs for initialization. */
     @Name("JavaCPP_getJavaVM") public static native @Cast("JavaVM*") Pointer getJavaVM();
+
+    /** Custom wrapper function for calling onLoad with roboVM since it's not supported for static libs */
+    @Name("JavaCPP_robovmOnLoad") @Raw(withEnv = true) public static native void robovmOnLoad();
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -405,7 +405,11 @@ public class Generator {
             loadSuffix = "";
             String p = clsProperties.getProperty("platform.library.static", "false").toLowerCase();
             if (p.equals("true") || p.equals("t") || p.equals("")) {
-                loadSuffix = "_" + clsProperties.getProperty("platform.library");
+                if (clsProperties.getProperty("platform").startsWith("ios")) {
+                    loadSuffix = ""; // onLoad for static libs not supported in RoboVM
+                } else {
+                    loadSuffix = "_" + clsProperties.getProperty("platform.library");
+                }
             }
         }
 
@@ -627,6 +631,13 @@ public class Generator {
             out.println("    total = info.dwNumberOfProcessors;");
             out.println("#endif");
             out.println("    return total;");
+            out.println("}");
+            out.println();
+            out.println("static inline void JavaCPP_robovmOnLoad(JNIEnv * env, jclass) {");
+            out.println("    JavaVM* tmp_vm = NULL;");
+            out.println("    env->GetJavaVM(&tmp_vm);");
+            out.println("    void* ptr;");
+            out.println("    JNI_OnLoad(tmp_vm, ptr);");
             out.println("}");
             out.println();
             out.println("static inline jint JavaCPP_totalCores() {");


### PR DESCRIPTION
Linking static libraries with JavaCPP in RoboVM currently is not working.

The JNI Invocation API from currently developed [RoboVM project](https://github.com/MobiVM/robovm)
is based on [Java 7 implementation](https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/invocation.html). 
Support for System.loadLibrary() for static libraries was just added in [Java 8](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/invocation.html). 

The current approach from JavaCPP for RoboVM is initializing JavaCPP via JNI_Onload_Libraryname which never gets executed since roboVM does not support it.
To solve this problem I came up with a simple wrapper function which eventually calls JNI_Onload.

Since the library gets statically linked, I was not sure which name to return in load().
