### PR TITLE
Add @Utf16String annotation to map java.lang.String to unsigned short*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add `@AsUtf16` annotation to map `java.lang.String` to `unsigned short*` (array of UTF-16 code units) ([pull #442](https://github.com/bytedeco/javacpp/pull/#442))
  * Add `BasicStringAdapter` and corresponding `@StdBasicString`, `@StdU16String`, and `@StdU32String` annotations ([pull #448](https://github.com/bytedeco/javacpp/pull/448))
  * Fix `Parser` failures on `try` blocks as function body, nested class templates, and aliases to namespaces starting with `::`
  * Prevent `Loader` from failing to find, load, or link libraries multiple times

--- a/src/main/java/org/bytedeco/javacpp/annotation/AsUtf16.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/AsUtf16.java
@@ -1,0 +1,17 @@
+package org.bytedeco.javacpp.annotation;
+
+import org.bytedeco.javacpp.tools.Generator;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation indicating that {@link java.lang.String} should be mapped
+ * to array of UTF-16 code units ({@code unsigned short*}) instead
+ * of byte array ({@code const char*})
+ *
+ * @see Generator
+ */
+
+@Documented @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.PARAMETER})
+public @interface AsUtf16 { }

--- a/src/main/java/org/bytedeco/javacpp/annotation/AsUtf16.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/AsUtf16.java
@@ -5,11 +5,12 @@ import org.bytedeco.javacpp.tools.Generator;
 import java.lang.annotation.*;
 
 /**
- * Annotation indicating that {@link java.lang.String} should be mapped
- * to array of UTF-16 code units ({@code unsigned short*}) instead
- * of byte array ({@code const char*})
+ * Indicates that {@link java.lang.String} should be mapped to array of UTF-16
+ * code units ({@code unsigned short*}) instead of byte array ({@code const char*}).
  *
  * @see Generator
+ *
+ * @author Alexey Rochev
  */
 
 @Documented @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -81,6 +81,7 @@ import org.bytedeco.javacpp.annotation.MemberGetter;
 import org.bytedeco.javacpp.annotation.MemberSetter;
 import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Namespace;
+import org.bytedeco.javacpp.annotation.AsUtf16;
 import org.bytedeco.javacpp.annotation.NoDeallocator;
 import org.bytedeco.javacpp.annotation.NoException;
 import org.bytedeco.javacpp.annotation.NoOffset;
@@ -937,18 +938,39 @@ public class Generator {
         out.println("}");
         out.println();
         if (handleExceptions || convertStrings) {
-            out.println("static JavaCPP_noinline jstring JavaCPP_createString(JNIEnv* env, const char* ptr) {");
+            out.println("#include <string>");
+            out.println("static JavaCPP_noinline jstring JavaCPP_createStringFromBytes(JNIEnv* env, const char* ptr, size_t length) {");
             out.println("    if (ptr == NULL) {");
             out.println("        return NULL;");
             out.println("    }");
             out.println("#ifdef MODIFIED_UTF8_STRING");
             out.println("    return env->NewStringUTF(ptr);");
             out.println("#else");
-            out.println("    size_t length = strlen(ptr);");
             out.println("    jbyteArray bytes = env->NewByteArray(length < INT_MAX ? length : INT_MAX);");
             out.println("    env->SetByteArrayRegion(bytes, 0, length < INT_MAX ? length : INT_MAX, (signed char*)ptr);");
             out.println("    return (jstring)env->NewObject(JavaCPP_getClass(env, " + jclasses.index(String.class) + "), JavaCPP_stringMID, bytes);");
             out.println("#endif");
+            out.println("}");
+            out.println();
+            out.println("static JavaCPP_noinline jstring JavaCPP_createStringFromBytes(JNIEnv* env, const char* ptr) {");
+            out.println("    if (ptr == NULL) {");
+            out.println("        return NULL;");
+            out.println("    }");
+            out.println("    return JavaCPP_createStringFromBytes(env, ptr, std::char_traits<char>::length(ptr));");
+            out.println("}");
+            out.println();
+            out.println("static JavaCPP_noinline jstring JavaCPP_createStringFromUTF16CodeUnits(JNIEnv* env, const unsigned short* ptr, size_t length) {");
+            out.println("    if (ptr == NULL) {");
+            out.println("        return NULL;");
+            out.println("    }");
+            out.println("    return env->NewString(ptr, length);");
+            out.println("}");
+            out.println();
+            out.println("static JavaCPP_noinline jstring JavaCPP_createStringFromUTF16CodeUnits(JNIEnv* env, const unsigned short* ptr) {");
+            out.println("    if (ptr == NULL) {");
+            out.println("        return NULL;");
+            out.println("    }");
+            out.println("    return JavaCPP_createStringFromUTF16CodeUnits(env, ptr, std::char_traits<unsigned short>::length(ptr));");
             out.println("}");
             out.println();
         }
@@ -977,12 +999,29 @@ public class Generator {
             out.println();
             out.println("static JavaCPP_noinline void JavaCPP_releaseStringBytes(JNIEnv* env, jstring str, const char* ptr) {");
             out.println("#ifdef MODIFIED_UTF8_STRING");
-            out.println("    if (str != NULL) {");
+            out.println("    if (str != NULL && ptr != NULL) {");
             out.println("        env->ReleaseStringUTFChars(str, ptr);");
             out.println("    }");
             out.println("#else");
             out.println("    delete[] ptr;");
             out.println("#endif");
+            out.println("}");
+            out.println();
+            out.println("static JavaCPP_noinline const unsigned short* JavaCPP_getStringUTF16CodeUnits(JNIEnv* env, jstring str) {");
+            out.println("    if (str == NULL) {");
+            out.println("        return NULL;");
+            out.println("    }");
+            out.println("    const jsize length = env->GetStringLength(str);");
+            out.println("    unsigned short* ptr = new (std::nothrow) unsigned short[length + 1];");
+            out.println("    if (ptr != NULL) {");
+            out.println("        env->GetStringRegion(str, 0, length, ptr);");
+            out.println("        ptr[length] = 0;");
+            out.println("    }");
+            out.println("    return ptr;");
+            out.println("}");
+            out.println();
+            out.println("static JavaCPP_noinline void JavaCPP_releaseStringUTF16CodeUnits(JNIEnv*, const unsigned short* ptr) {");
+            out.println("    delete[] ptr;");
             out.println("}");
             out.println();
         }
@@ -1012,9 +1051,9 @@ public class Generator {
             out.println("    try {");
             out.println("        throw;");
             out.println("    } catch (GENERIC_EXCEPTION_CLASS& e) {");
-            out.println("        str = JavaCPP_createString(env, e.GENERIC_EXCEPTION_TOSTRING);");
+            out.println("        str = JavaCPP_createStringFromBytes(env, e.GENERIC_EXCEPTION_TOSTRING);");
             out.println("    } catch (...) {");
-            out.println("        str = JavaCPP_createString(env, \"Unknown exception.\");");
+            out.println("        str = JavaCPP_createStringFromBytes(env, \"Unknown exception.\");");
             out.println("    }");
             out.println("    jmethodID mid = JavaCPP_getMethodID(env, i, \"<init>\", \"(Ljava/lang/String;)V\");");
             out.println("    if (mid == NULL) {");
@@ -2029,7 +2068,7 @@ public class Generator {
                 Annotation passBy = by(methodInfo, j);
                 String cast = cast(methodInfo, j);
                 String[] typeName = methodInfo.parameterRaw[j] ? new String[] { "" }
-                        : cppTypeName(methodInfo.parameterTypes[j]);
+                        : cppTypeName(methodInfo.parameterTypes[j], methodInfo.parameterAnnotations[j]);
                 AdapterInformation adapterInfo = methodInfo.parameterRaw[j] ? null
                         : adapterInformation(false, methodInfo, j);
 
@@ -2099,7 +2138,7 @@ public class Generator {
                     }
                 } else if (methodInfo.parameterTypes[j] == String.class) {
                     passesStrings = true;
-                    out.println("JavaCPP_getStringBytes(env, arg" + j + ");");
+                    out.println(getStringData("arg" + j, methodInfo.parameterAnnotations[j]));
                     if (adapterInfo != null || prevAdapterInfo != null) {
                         out.println("    jlong size" + j + " = 0;");
                         out.println("    void* owner" + j + " = (void*)ptr" + j + ";");
@@ -2268,19 +2307,19 @@ public class Generator {
                     if (FunctionPointer.class.isAssignableFrom(methodInfo.returnType)) {
                         out.println("    rptr = new (std::nothrow) " + valueTypeName + ";");
                         if (returnBy instanceof ByPtrPtr) {
-                            String[] cpptypeName = cppTypeName(methodInfo.returnType);
+                            String[] cpptypeName = cppTypeName(methodInfo.returnType, methodInfo.annotations);
                             returnPrefix = cpptypeName[0] + "* rptrptr" + cpptypeName[1] + " = ";
                         }
                     }
                 } else if (methodInfo.returnType == String.class) {
                     out.println("    jstring rarg = NULL;");
-                    out.println("    const char* rptr;");
+                    out.println("    " + typeName[0] + " rptr;");
                     if (returnBy instanceof ByRef) {
-                        returnPrefix = "std::string rstr(";
+                        returnPrefix = "std::basic_string<" + valueTypeName + "> rstr(";
                     } else if (returnBy instanceof ByPtrPtr) {
-                        returnPrefix = "rptr = NULL; const char** rptrptr = (const char**)";
+                        returnPrefix = "rptr = NULL; " + typeName[0] + "* rptrptr = (" + typeName[0] + "*)";
                     } else {
-                        returnPrefix += "(const char*)";
+                        returnPrefix += "(" + typeName[0] + ")";
                     }
                 } else {
                     logger.warn("Method \"" + methodInfo.method + "\" has unsupported return type \"" +
@@ -2691,7 +2730,7 @@ public class Generator {
                 } else if (methodInfo.returnType == String.class) {
                     passesStrings = true;
                     out.println(indent + "if (rptr != NULL) {");
-                    out.println(indent + "    rarg = JavaCPP_createString(env, rptr);");
+                    out.println(indent + "    rarg = " + createString("rptr", (adapterInfo != null ? "radapter" : null), methodInfo.annotations));
                     out.println(indent + "}");
                 } else if (methodInfo.returnType.isArray() &&
                         methodInfo.returnType.getComponentType().isPrimitive()) {
@@ -2783,7 +2822,7 @@ public class Generator {
                             ", JavaCPP_addressFID, ptr_to_jlong(ptr" + j + "));");
                 }
             } else if (methodInfo.parameterTypes[j] == String.class) {
-                out.println("    JavaCPP_releaseStringBytes(env, arg" + j + ", ptr" + j + ");");
+                out.println("    " + releaseStringData("arg" + j, "ptr" + j, methodInfo.parameterAnnotations[j]));
             } else if (methodInfo.parameterTypes[j].isArray() &&
                     methodInfo.parameterTypes[j].getComponentType().isPrimitive()) {
                 for (int k = 0; adapterInfo != null && k < adapterInfo.argc; k++) {
@@ -2966,7 +3005,7 @@ public class Generator {
         }
         String callbackReturnCast = cast(callbackReturnType, callbackAnnotations);
         Annotation returnBy = by(callbackAnnotations);
-        String[] returnTypeName = cppTypeName(callbackReturnType);
+        String[] returnTypeName = cppTypeName(callbackReturnType, callbackAnnotations);
         String returnValueTypeName = valueTypeName(returnTypeName);
         AdapterInformation returnAdapterInfo = adapterInformation(false, returnValueTypeName, callbackAnnotations);
         boolean throwsExceptions = !noException(cls, callbackMethod);
@@ -3001,7 +3040,7 @@ public class Generator {
                         out.println("    }");
                     }
                 } else {
-                    String[] typeName = cppTypeName(callbackParameterTypes[j]);
+                    String[] typeName = cppTypeName(callbackParameterTypes[j], callbackParameterAnnotations[j]);
                     String valueTypeName = valueTypeName(typeName);
                     AdapterInformation adapterInfo = adapterInformation(false, valueTypeName, callbackParameterAnnotations[j]);
 
@@ -3088,7 +3127,12 @@ public class Generator {
                         out.println("    args[" + j + "].l = obj" + j + ";");
                     } else if (callbackParameterTypes[j] == String.class) {
                         passesStrings = true;
-                        out.println("    jstring obj" + j + " = JavaCPP_createString(env, (const char*)" + (adapterInfo != null ? "adapter" : "arg") + j + ");");
+                        if (adapterInfo != null) {
+                            final String adapter = "adapter" + j;
+                            out.println("    jstring obj" + j + " = " + createString("(" + typeName[0] + ") " + adapter, adapter, callbackParameterAnnotations[j]));
+                        } else {
+                            out.println("    jstring obj" + j + " = " + createString("(" + typeName[0] + ") arg" + j, null, callbackParameterAnnotations[j]));
+                        }
                         out.println("    args[" + j + "].l = obj" + j + ";");
                     } else if (callbackParameterTypes[j].isArray() &&
                             callbackParameterTypes[j].getComponentType().isPrimitive()) {
@@ -3171,7 +3215,7 @@ public class Generator {
 
         for (int j = 0; j < callbackParameterTypes.length; j++) {
             if (Pointer.class.isAssignableFrom(callbackParameterTypes[j])) {
-                String[] typeName = cppTypeName(callbackParameterTypes[j]);
+                String[] typeName = cppTypeName(callbackParameterTypes[j], callbackParameterAnnotations[j]);
                 Annotation passBy = by(callbackParameterAnnotations[j]);
                 String cast = cast(callbackParameterTypes[j], callbackParameterAnnotations[j]);
                 String valueTypeName = valueTypeName(typeName);
@@ -3248,7 +3292,7 @@ public class Generator {
                 }
             } else if (callbackReturnType == String.class) {
                 passesStrings = true;
-                out.println("    " + returnTypeName[0] + " rptr" + returnTypeName[1] + " = JavaCPP_getStringBytes(env, rarg);");
+                out.println("    " + returnTypeName[0] + " rptr" + returnTypeName[1] + " = " + getStringData("rarg", callbackAnnotations));
                 if (returnAdapterInfo != null) {
                     out.println("    jlong rsize = 0;");
                     out.println("    void* rowner = (void*)rptr;");
@@ -3930,7 +3974,7 @@ public class Generator {
                     // prioritize @Cast
                     continue;
                 }
-                typeName = cppTypeName(type);
+                typeName = cppTypeName(type, annotations);
                 if (typeName[0].contains("(*")) {
                     // function pointer
                     if (b.length > 0 && b[0] && !typeName[0].endsWith(" const")) {
@@ -3958,12 +4002,12 @@ public class Generator {
             logger.warn("Without \"Adapter\", \"Cast\" and \"Const\" annotations are mutually exclusive.");
         }
         if (typeName == null) {
-            typeName = cppTypeName(type);
+            typeName = cppTypeName(type, annotations);
         }
         return typeName;
     }
 
-    String[] cppTypeName(Class<?> type) {
+    String[] cppTypeName(Class<?> type, Annotation[] annotations) {
         String prefix = "", suffix = "";
         if (type == Buffer.class || type == Pointer.class) {
             prefix = "void*";
@@ -3986,7 +4030,11 @@ public class Generator {
         } else if (type == PointerPointer.class) {
             prefix = "void**";
         } else if (type == String.class) {
-            prefix = "const char*";
+            if (asUtf16CodeUnits(annotations)) {
+                prefix = "const unsigned short*";
+            } else {
+                prefix = "const char*";
+            }
         } else if (type == byte.class) {
             prefix = "signed char";
         } else if (type == long.class) {
@@ -4013,6 +4061,10 @@ public class Generator {
             }
         }
         return new String[] { prefix, suffix };
+    }
+
+    String[] cppTypeName(Class<?> type) {
+        return cppTypeName(type, null);
     }
 
     String[] cppFunctionTypeName(Method... functionMethods) {
@@ -4250,5 +4302,35 @@ public class Generator {
             }
         }
         return mangledName.toString();
+    }
+
+    private static boolean asUtf16CodeUnits(Annotation[] annotations) {
+        if (annotations == null) {
+            return false;
+        }
+        for (Annotation annotation : annotations) {
+            if (annotation instanceof AsUtf16) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String createString(String ptr, String adapter, Annotation[] annotations) {
+        return (asUtf16CodeUnits(annotations) ? "JavaCPP_createStringFromUTF16CodeUnits(env, "
+                                              : "JavaCPP_createStringFromBytes(env, ")
+                + ptr + (adapter != null ? ", " + adapter + ".size);" : ");");
+    }
+
+    private static String getStringData(String str, Annotation[] annotations) {
+        return (asUtf16CodeUnits(annotations) ? "JavaCPP_getStringUTF16CodeUnits(env, "
+                                              : "JavaCPP_getStringBytes(env, ")
+                + str + ");";
+    }
+
+    private static String releaseStringData(String str, String ptr, Annotation[] annotations) {
+        return (asUtf16CodeUnits(annotations) ? "JavaCPP_releaseStringUTF16CodeUnits(env, "
+                                              : "JavaCPP_releaseStringBytes(env, " + str + ", ")
+                + ptr + ");";
     }
 }

--- a/src/test/java/org/bytedeco/javacpp/AdapterTest.java
+++ b/src/test/java/org/bytedeco/javacpp/AdapterTest.java
@@ -37,6 +37,7 @@ import org.bytedeco.javacpp.annotation.StdU32String;
 import org.bytedeco.javacpp.annotation.StdVector;
 import org.bytedeco.javacpp.annotation.StdWString;
 import org.bytedeco.javacpp.annotation.UniquePtr;
+import org.bytedeco.javacpp.annotation.AsUtf16;
 import org.bytedeco.javacpp.tools.Builder;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,6 +55,7 @@ public class AdapterTest {
     static native @StdString BytePointer testStdString(@StdString BytePointer str);
 
     static native @StdWString CharPointer testStdWString(@StdWString CharPointer str);
+    static native @StdWString @AsUtf16 String testStdWString(@StdWString @AsUtf16 String str);
     static native @StdWString IntPointer testStdWString(@StdWString IntPointer str);
 
     static native @StdBasicString("char") String testStdString2(@StdBasicString("char") String str);
@@ -62,12 +64,14 @@ public class AdapterTest {
     static native @Cast("wchar_t*") @StdBasicString("wchar_t") IntPointer testStdWString2(@Cast("wchar_t*") @StdBasicString("wchar_t") IntPointer str);
 
     static native @StdU16String CharPointer testStdU16String(@StdU16String CharPointer str);
+    static native @StdU16String @AsUtf16 String testStdU16String(@StdU16String @AsUtf16 String str);
     static native @StdU32String IntPointer testStdU32String(@StdU32String IntPointer str);
 
     static native String testCharString(String str);
     static native @Cast("char*") BytePointer testCharString(@Cast("char*") BytePointer str);
 
     static native CharPointer testShortString(CharPointer str);
+    static native @AsUtf16 String testShortString(@AsUtf16 String str);
 
     static native IntPointer testIntString(IntPointer str);
 
@@ -165,8 +169,12 @@ public class AdapterTest {
             // UTF-16
             CharPointer textCharPtr2 = testStdWString(textCharPtr1);
             assertEquals(textStr1, textCharPtr2.getString());
+
             CharPointer textCharPtr3 = testStdWString2(textCharPtr1);
             assertEquals(textStr1, textCharPtr3.getString());
+
+            String textStr4 = testStdWString(textStr1);
+            assertEquals(textStr1, textStr4);
         } else {
             // UTF-32
             IntPointer textIntPtr2 = testStdWString(textIntPtr1);
@@ -177,6 +185,9 @@ public class AdapterTest {
 
         CharPointer textCharPtr4 = testStdU16String(textCharPtr1);
         assertEquals(textStr1, textCharPtr4.getString());
+
+        String textStr5 = testStdU16String(textStr1);
+        assertEquals(textStr1, textStr5);
 
         IntPointer textIntPtr4 = testStdU32String(textIntPtr1);
         assertEquals(textStr1, textIntPtr4.getString());
@@ -205,11 +216,15 @@ public class AdapterTest {
     @Test public void testShortString() {
         System.out.println("ShortString");
 
-        String textStr = "This is a normal ASCII string.";
-        CharPointer textPtr1 = new CharPointer(textStr);
+        String textStr1 = "This is a normal ASCII string.";
+        CharPointer textPtr1 = new CharPointer(textStr1);
         CharPointer textPtr2 = testShortString(textPtr1);
-        assertEquals(textStr, textPtr1.getString());
-        assertEquals(textStr, textPtr2.getString());
+        assertEquals(textStr1, textPtr1.getString());
+        assertEquals(textStr1, textPtr2.getString());
+
+        String textStr2 = testShortString(textStr1);
+        assertEquals(textStr1, textStr2);
+
         System.gc();
     }
 

--- a/src/test/resources/org/bytedeco/javacpp/AdapterTest.h
+++ b/src/test/resources/org/bytedeco/javacpp/AdapterTest.h
@@ -31,6 +31,10 @@ char *testCharString(const char *str) {
     // memory leak...
 }
 
+const unsigned short *testShortString(const unsigned short *str) {
+    return str;
+}
+
 unsigned short *testShortString(unsigned short *str) {
     return str;
 }


### PR DESCRIPTION
Currently, if your native string type is UTF-16 encoded, and you want to map it to java.lang.String, you need to expose it as CharPointer and call its getString() method. It works, but it involves creation of intermediary Java object (CharPointer), C++ -> Java method call to inititalize CharPointer, and additional array copy.

This patch allows to do it much faster by directly using NewString() JNI function to directly create String from `const jchar*` (aka `const unsigned short*`).