### PR TITLE
Use reflection for PointerBufferPoolMXBean to avoid warnings on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Prevent Android from trying to load `PointerBufferPoolMXBean` by using it via reflection ([pull #447](https://github.com/bytedeco/javacpp/pull/447))
  * Fix Android build properties for NDK r22 and move legacy to `android-*-gcc.properties` ([pull #444](https://github.com/bytedeco/javacpp/pull/444))
  * Add support for Mac on ARM processors
  * Fix `Loader` not searching for libraries in more than one package

--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -515,8 +515,8 @@ public class Pointer implements AutoCloseable {
                 Class c = Class.forName("org.bytedeco.javacpp.tools.PointerBufferPoolMXBean");
                 Method method = c.getDeclaredMethod("register");
                 method.invoke(null);
-            } catch (ReflectiveOperationException t) {
-                logger.warn("Could not load PointerBufferPoolMXBean: " + t);
+            } catch (ReflectiveOperationException e) {
+                logger.warn("Could not register PointerBufferPoolMXBean: " + e);
             }
         }
     }

--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -512,10 +512,10 @@ public class Pointer implements AutoCloseable {
         String mx = System.getProperty("org.bytedeco.javacpp.mxbean", "false").toLowerCase();
         if (mx.equals("true") || mx.equals("t") || mx.equals("")) {
             try {
-                Class c = Class.forName("PointerBufferPoolMXBean");
+                Class c = Class.forName("org.bytedeco.javacpp.tools.PointerBufferPoolMXBean");
                 Method method = c.getDeclaredMethod("register");
                 method.invoke(null);
-            } catch (Throwable t) {
+            } catch (ReflectiveOperationException t) {
                 logger.warn("Could not load PointerBufferPoolMXBean: " + t);
             }
         }

--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -34,7 +34,6 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.tools.Generator;
-import org.bytedeco.javacpp.tools.PointerBufferPoolMXBean;
 import org.bytedeco.javacpp.tools.Logger;
 
 /**
@@ -512,7 +511,13 @@ public class Pointer implements AutoCloseable {
 
         String mx = System.getProperty("org.bytedeco.javacpp.mxbean", "false").toLowerCase();
         if (mx.equals("true") || mx.equals("t") || mx.equals("")) {
-            PointerBufferPoolMXBean.register();
+            try {
+                Class c = Class.forName("PointerBufferPoolMXBean");
+                Method method = c.getDeclaredMethod("register");
+                method.invoke(null);
+            } catch (Throwable t) {
+                logger.warn("Could not load PointerBufferPoolMXBean: " + t);
+            }
         }
     }
 


### PR DESCRIPTION
cc https://github.com/bytedeco/javacpp/issues/446#issuecomment-752294063