### PR TITLE
Added a flag to prevent system load library

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -916,10 +916,19 @@ public class Loader {
     static boolean canCreateSymbolicLink = true;
 
     static boolean pathsFirst = false;
+
+    static boolean systemLoadLibrary = true;
+    
     static {
         String s = System.getProperty("org.bytedeco.javacpp.pathsfirst", "false").toLowerCase();
         s = System.getProperty("org.bytedeco.javacpp.pathsFirst", s).toLowerCase();
-        pathsFirst = s.equals("true") || s.equals("t") || s.equals("");
+	pathsFirst = s.equals("true") || s.equals("t") || s.equals("");
+
+	/* Avoids System.loadLibrary load which searches through allow
+	 * all paths and delays overall load time */
+	String l = System.getProperty("org.bytedeco.javacpp.systemloadlibrary", "true").toLowerCase();
+	l = System.getProperty("org.bytedeco.javacpp.systemloadlibrary", l).toLowerCase();
+	systemLoadLibrary = l.equals("true") || l.equals("t") || l.equals("");
     }
 
     /** Creates and returns {@code System.getProperty("org.bytedeco.javacpp.cachedir")} or {@code ~/.javacpp/cache/} when not set. */
@@ -1701,7 +1710,7 @@ public class Loader {
                         }
                     }
                 }
-                if (!loadedByLoadLibrary0) {
+		if (!loadedByLoadLibrary0 && systemLoadLibrary) {
                     System.loadLibrary(libname);
                 }
                 return libname;

--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -917,18 +917,11 @@ public class Loader {
 
     static boolean pathsFirst = false;
 
-    static boolean systemLoadLibrary = true;
     
     static {
         String s = System.getProperty("org.bytedeco.javacpp.pathsfirst", "false").toLowerCase();
         s = System.getProperty("org.bytedeco.javacpp.pathsFirst", s).toLowerCase();
 	pathsFirst = s.equals("true") || s.equals("t") || s.equals("");
-
-	/* Avoids System.loadLibrary load which searches through allow
-	 * all paths and delays overall load time */
-	String l = System.getProperty("org.bytedeco.javacpp.systemloadlibrary", "true").toLowerCase();
-	l = System.getProperty("org.bytedeco.javacpp.systemloadlibrary", l).toLowerCase();
-	systemLoadLibrary = l.equals("true") || l.equals("t") || l.equals("");
     }
 
     /** Creates and returns {@code System.getProperty("org.bytedeco.javacpp.cachedir")} or {@code ~/.javacpp/cache/} when not set. */
@@ -1710,7 +1703,7 @@ public class Loader {
                         }
                     }
                 }
-		if (!loadedByLoadLibrary0 && systemLoadLibrary) {
+		if (!loadedByLoadLibrary0 && System.getProperty("java.library.path", "").length() > 0) {
                     System.loadLibrary(libname);
                 }
                 return libname;


### PR DESCRIPTION
Currently, even if java.library.path is set to nothing, the System.loadLibrary is called which searches through all paths to load the libraries. This creates a significant delay in startup. The pull will allow a switch to control if System.loadLibrary is called and the fix is backwards compatible to prevent breaking existing codecase. 
 
