### PR TITLE
Add STRING_BYTES_CHARSET define to explicitly set charset for mapping java.lang.String to/from bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Map `String` to `char*` with `Charset.forName(STRING_BYTES_CHARSET)` when that macro is defined ([pull #460](https://github.com/bytedeco/javacpp/pull/460))
  * Fix `Loader.ClassProperties` not always getting overridden correctly when defined multiple times
  * Allow `Loader.load()` to also rename executables on extraction to output filenames specified with the `#` character
  * Add `@AsUtf16` annotation to map `java.lang.String` to `unsigned short*` (array of UTF-16 code units) ([pull #442](https://github.com/bytedeco/javacpp/pull/442))

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -500,7 +500,7 @@ public class Generator {
         out.println("static jmethodID JavaCPP_toStringMID = NULL;");
         out.println("#ifdef STRING_BYTES_CHARSET");
         out.println("#ifdef MODIFIED_UTF8_STRING");
-        out.println("#error \"STRING_BYTES_CHARSET and MODIFIED_UTF8_STRING must not be defined together\"");
+        out.println("#pragma message (\"warning: STRING_BYTES_CHARSET and MODIFIED_UTF8_STRING are mutually exclusive.\")");
         out.println("#endif");
         out.println("static jobject JavaCPP_stringBytesCharset = NULL;");
         out.println("static jmethodID JavaCPP_stringWithCharsetMID = NULL;");


### PR DESCRIPTION
Right now, JavaCPP uses either default Java charset or Modified UTF-8 (if MODIFIED_UTF8_STRING is defined)
when mapping java.lang.String to/from bytes (or containers like std::string via adapters).

Add STRING_BYTES_CHARSET define to explicitly set charset that will be used in these conversions.
STRING_BYTES_CHARSET, if defined, must be a string literal containing name or alias of supported Java charset (e.g. "UTF-8").