### PR TITLE
Add `Info.readOnlyMembers` to disable generating setters for publi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add `Info.immutable` to disable generating setters for public data members ([pull #461](https://github.com/bytedeco/javacpp/pull/461))
  * Map `String` to `char*` with `Charset.forName(STRING_BYTES_CHARSET)` when that macro is defined ([pull #460](https://github.com/bytedeco/javacpp/pull/460))
  * Fix `Loader.ClassProperties` not always getting overridden correctly when defined multiple times
  * Allow `Loader.load()` to also rename executables on extraction to output filenames specified with the `#` character

--- a/src/main/java/org/bytedeco/javacpp/tools/Context.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Context.java
@@ -43,10 +43,10 @@ class Context {
         javaName = c.javaName;
         constName = c.constName;
         constBaseName = c.constBaseName;
+        immutable = c.immutable;
         inaccessible = c.inaccessible;
         objectify = c.objectify;
         virtualize = c.virtualize;
-        readOnlyMembers = c.readOnlyMembers;
         variable = c.variable;
         infoMap = c.infoMap;
         templateMap = c.templateMap;
@@ -60,10 +60,10 @@ class Context {
     String javaName = null;
     String constName = null;
     String constBaseName = null;
+    boolean immutable = false;
     boolean inaccessible = false;
     boolean objectify = false;
     boolean virtualize = false;
-    boolean readOnlyMembers = false;
     Declarator variable = null;
     InfoMap infoMap = null;
     TemplateMap templateMap = null;

--- a/src/main/java/org/bytedeco/javacpp/tools/Context.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Context.java
@@ -46,6 +46,7 @@ class Context {
         inaccessible = c.inaccessible;
         objectify = c.objectify;
         virtualize = c.virtualize;
+        readOnlyMembers = c.readOnlyMembers;
         variable = c.variable;
         infoMap = c.infoMap;
         templateMap = c.templateMap;
@@ -62,6 +63,7 @@ class Context {
     boolean inaccessible = false;
     boolean objectify = false;
     boolean virtualize = false;
+    boolean readOnlyMembers = false;
     Declarator variable = null;
     InfoMap infoMap = null;
     TemplateMap templateMap = null;

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -95,6 +95,8 @@ public class Info {
     /** Outputs declarations for this class into their subclasses as well.
      * Also adds methods for explicit casting, as done for multiple inheritance by default. */
     boolean flatten = false;
+    /** Disables generation of setters for public data members of a class */
+    boolean immutable = false;
     /** Map global functions to instance methods, without {@code static} modifier, to implement an interface, etc. */
     boolean objectify = false;
     /** Attempts to translate naively the statements of variable-like macros to Java. */
@@ -108,8 +110,6 @@ public class Info {
     boolean purify = false;
     /** Annotates virtual functions with @{@link Virtual} and adds appropriate constructors. */
     boolean virtualize = false;
-    /** Disables generation of setters for public data members of a class */
-    boolean readOnlyMembers = false;
     /** Allows to override the base class of {@link #pointerTypes}. Defaults to {@link Pointer}. */
     String base = null;
     /** Replaces the code associated with the declaration of C++ identifiers, before parsing. */
@@ -132,6 +132,8 @@ public class Info {
     public Info enumerate(boolean enumerate) { this.enumerate = enumerate; return this; }
     public Info flatten() { this.flatten = true; return this; }
     public Info flatten(boolean flatten) { this.flatten = flatten; return this; }
+    public Info immutable() { this.immutable = true; return this; }
+    public Info immutable(boolean immutable) { this.immutable = immutable; return this; }
     public Info objectify() { this.objectify = true; return this; }
     public Info objectify(boolean objectify) { this.objectify = objectify; return this; }
     public Info translate() { this.translate = true; return this; }
@@ -144,8 +146,6 @@ public class Info {
     public Info purify(boolean purify) { this.purify = purify; return this; }
     public Info virtualize() { this.virtualize = true; return this; }
     public Info virtualize(boolean virtualize) { this.virtualize = virtualize; return this; }
-    public Info readOnlyMembers() { this.readOnlyMembers = true; return this; }
-    public Info readOnlyMembers(boolean readOnly) { this.readOnlyMembers = readOnly; return this; }
     public Info base(String base) { this.base = base; return this; }
     public Info cppText(String cppText) { this.cppText = cppText; return this; }
     public Info javaText(String javaText) { this.javaText = javaText; return this; }

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -108,6 +108,8 @@ public class Info {
     boolean purify = false;
     /** Annotates virtual functions with @{@link Virtual} and adds appropriate constructors. */
     boolean virtualize = false;
+    /** Disables generation of setters for public data members of a class */
+    boolean readOnlyMembers = false;
     /** Allows to override the base class of {@link #pointerTypes}. Defaults to {@link Pointer}. */
     String base = null;
     /** Replaces the code associated with the declaration of C++ identifiers, before parsing. */
@@ -142,6 +144,8 @@ public class Info {
     public Info purify(boolean purify) { this.purify = purify; return this; }
     public Info virtualize() { this.virtualize = true; return this; }
     public Info virtualize(boolean virtualize) { this.virtualize = virtualize; return this; }
+    public Info readOnlyMembers() { this.readOnlyMembers = true; return this; }
+    public Info readOnlyMembers(boolean readOnly) { this.readOnlyMembers = readOnly; return this; }
     public Info base(String base) { this.base = base; return this; }
     public Info cppText(String cppText) { this.cppText = cppText; return this; }
     public Info javaText(String javaText) { this.javaText = javaText; return this; }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -2439,7 +2439,7 @@ public class Parser {
                     dcl.type.annotations = dcl.type.annotations.replaceAll("@Name\\(.*\\) ", "");
                     javaName = metadcl.javaName + "_" + shortName;
                 }
-                final boolean hasSetter = !(dcl.type.constValue && dcl.indirections == 0) && !dcl.constPointer && !dcl.type.constExpr && !context.readOnlyMembers;
+                final boolean hasSetter = !(dcl.type.constValue && dcl.indirections == 0) && !dcl.constPointer && !dcl.type.constExpr && !context.immutable;
                 if (!hasSetter) {
                     decl.text += "@MemberGetter ";
                 }
@@ -2485,7 +2485,7 @@ public class Parser {
                 }
                 tokens.index = backIndex;
                 Declarator dcl2 = declarator(context, null, -1, false, n, false, false);
-                final boolean hasSetter = !dcl.type.constValue && !dcl.constPointer && !(dcl2.indirections < 2) && !dcl2.type.constExpr && !context.readOnlyMembers;
+                final boolean hasSetter = !dcl.type.constValue && !dcl.constPointer && !(dcl2.indirections < 2) && !dcl2.type.constExpr && !context.immutable;
                 if (!hasSetter) {
                     decl.text += "@MemberGetter ";
                 }
@@ -3175,8 +3175,8 @@ public class Parser {
         if (info != null) {
             if (info.virtualize)
                 ctx.virtualize = true;
-            if (info.readOnlyMembers)
-                ctx.readOnlyMembers = true;
+            if (info.immutable)
+                ctx.immutable = true;
         }
         ctx.baseType = base.cppName;
 


### PR DESCRIPTION
Sometimes it is needed to pass data from C++ to Java in form of struct, but there is no need to make it mutable. In this case, generated setter methods are unused and only increase size of native library and compiled Java classes.