### PR TITLE
Use uninitialized_copy to copy into uninitialized memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+ * Use `std::uninitialized_copy` in `VectorAdapter` to make sure copy constructors get called ([pull #465](https://github.com/bytedeco/javacpp/pull/465))
+
 ### March 8, 2021 version 1.5.5
  * Ensure `System.gc()` never gets called with "org.bytedeco.javacpp.nopointergc" ([issue tensorflow/java#208](https://github.com/tensorflow/java/issues/208))
  * Add `Info.immutable` to disable generating setters for public data members ([pull #461](https://github.com/bytedeco/javacpp/pull/461))

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -1119,7 +1119,7 @@ public class Generator {
             out.println("            ptr = (P*)(operator new(sizeof(P) * vec.size(), std::nothrow_t()));");
             out.println("        }");
             out.println("        if (ptr) {");
-            out.println("            std::copy(vec.begin(), vec.end(), ptr);");
+            out.println("            std::uninitialized_copy(vec.begin(), vec.end(), ptr);");
             out.println("        }");
             out.println("        size = vec.size();");
             out.println("        owner = ptr;");


### PR DESCRIPTION
Use `uninitialized_copy` to prevent from calling `copy assignment operator=()` on uninitialised memory (unconstructed `this`).