### PR TITLE
upgrade BND to 5.3.0 for Java 15+ compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
-    <bnd.version>4.2.0</bnd.version>
+    <bnd.version>5.3.0</bnd.version>
     <javacpp.platform.root></javacpp.platform.root>
     <javacpp.platform.suffix></javacpp.platform.suffix>
     <javacpp.platform.compiler></javacpp.platform.compiler>

--- a/src/it/osgi/pom.xml
+++ b/src/it/osgi/pom.xml
@@ -9,7 +9,7 @@
   <description>Integration Tests for JavaCPP running in OSGi</description>
   
   <properties>
-    <bnd.version>4.2.0</bnd.version>
+    <bnd.version>5.3.0</bnd.version>
     <lib.path>${os.name}-${os.arch}/${lib.name}</lib.path>
   </properties>
   


### PR DESCRIPTION
The maven process-class phase fails with exception:

```
java.util.ConcurrentModificationException
    at java.util.TreeMap.callMappingFunctionWithCheck (TreeMap.java:742)
    at java.util.TreeMap.computeIfAbsent (TreeMap.java:558)
    at aQute.bnd.osgi.Jar.putResource (Jar.java:288)
    at aQute.bnd.osgi.Jar$1.visitFile (Jar.java:202)
    at aQute.bnd.osgi.Jar$1.visitFile (Jar.java:177)
    at java.nio.file.Files.walkFileTree (Files.java:2804)
    at aQute.bnd.osgi.Jar.buildFromDirectory (Jar.java:176)
    at aQute.bnd.osgi.Jar.<init> (Jar.java:119)
    at aQute.bnd.osgi.Jar.<init> (Jar.java:148)
    at aQute.bnd.osgi.Analyzer.addClasspath (Analyzer.java:2490)
    at aQute.bnd.maven.plugin.BndMavenPlugin.execute (BndMavenPlugin.java:200)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:64)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:564)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```

when using JDK 15+

Upgrading BND plugin from 4.2.0 to 5.3.0 seems to solve the issue.
