### PR TITLE
#483 - Javacpp does not export package required by presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add missing `presets/package-info.java` required for OSGi and add profile for M2Eclipse ([pull #490](https://github.com/bytedeco/javacpp/pull/490))
  * Remove unnecessary mutex lock for pthreads on callbacks in `Generator` ([pull #489](https://github.com/bytedeco/javacpp/pull/489))
  * Fix `@AsUtf16` handling for setter methods paired with getters in `Generator` ([pull #488](https://github.com/bytedeco/javacpp/pull/488))
  * Allow defining `NO_JNI_DETACH_THREAD` to avoid overhead from pthreads on callbacks ([issue #486](https://github.com/bytedeco/javacpp/issues/486))

--- a/pom.xml
+++ b/pom.xml
@@ -581,6 +581,72 @@ Import-Package: \
         </plugins>
       </build>
     </profile>
+    
+    <!-- *********************************** -->
+    <!-- * Eclipse: m2e lifecycle bindings * -->
+    <!-- *********************************** -->
+    <profile>
+      <id>m2e</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!--This plugin's configuration is used to store Eclipse m2e settings 
+                only. It has no influence on the Maven build itself. -->
+            <plugin>
+              <groupId>org.eclipse.m2e</groupId>
+              <artifactId>lifecycle-mapping</artifactId>
+              <version>1.0.0</version>
+              <configuration>
+                <lifecycleMappingMetadata>
+                  <pluginExecutions>
+                    <!-- *********************************************** -->
+                    <!-- The Maven Dev Connector for Eclipse m2e is no   -->
+                    <!-- longer maintained. We copy the relevant part    --> 
+                    <!-- of the lifecycle mapping for the                -->
+                    <!-- maven-plugin-plugin here.                       -->
+                    <!--                                                 -->
+                    <!-- See https://github.com/ifedorenko/com.ifedorenko.m2e.mavendev/blob/master/com.ifedorenko.m2e.mavendev/lifecycle-mapping-metadata.xml -->
+                    <!-- *********************************************** -->
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-plugin-plugin</artifactId>
+                        <versionRange>[3.5.2,)</versionRange>
+                        <goals>
+                          <goal>descriptor</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <execute>
+                          <runOnIncremental>false</runOnIncremental>
+                        </execute>
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-plugin-plugin</artifactId>
+                        <versionRange>[3.5.2,)</versionRange>
+                        <goals>
+                          <goal>helpmojo</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                  </pluginExecutions>
+                </lifecycleMappingMetadata>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -581,7 +581,7 @@ Import-Package: \
         </plugins>
       </build>
     </profile>
-    
+
     <!-- *********************************** -->
     <!-- * Eclipse: m2e lifecycle bindings * -->
     <!-- *********************************** -->
@@ -595,7 +595,7 @@ Import-Package: \
       <build>
         <pluginManagement>
           <plugins>
-            <!--This plugin's configuration is used to store Eclipse m2e settings 
+            <!--This plugin's configuration is used to store Eclipse m2e settings
                 only. It has no influence on the Maven build itself. -->
             <plugin>
               <groupId>org.eclipse.m2e</groupId>
@@ -606,7 +606,7 @@ Import-Package: \
                   <pluginExecutions>
                     <!-- *********************************************** -->
                     <!-- The Maven Dev Connector for Eclipse m2e is no   -->
-                    <!-- longer maintained. We copy the relevant part    --> 
+                    <!-- longer maintained. We copy the relevant part    -->
                     <!-- of the lifecycle mapping for the                -->
                     <!-- maven-plugin-plugin here.                       -->
                     <!--                                                 -->
@@ -649,4 +649,5 @@ Import-Package: \
       </build>
     </profile>
   </profiles>
+
 </project>

--- a/src/main/java/org/bytedeco/javacpp/presets/package-info.java
+++ b/src/main/java/org/bytedeco/javacpp/presets/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Contains base presets which can be inherited.
+ */
+@org.osgi.annotation.bundle.Export
+package org.bytedeco.javacpp.presets;


### PR DESCRIPTION
- Add package-info with OSGI annotation so that the presets packages is exported for use by e.g. the openblas preset
- Add m2e lifecycle bindings for the maven-plugin-plugin to avoid error in Eclipse when importing the project