### PR TITLE
Add `Info.beanify()` to add JavaBeans-style prefixes for getter and setters of member variables generated by `Parser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add `Info.beanify` to have `Parser` generate JavaBeans-style getters and setters ([pull #495](https://github.com/bytedeco/javacpp/pull/495))
  * Allow `Parser` to use `Info.javaNames` for function names containing parameters as well ([issue #492](https://github.com/bytedeco/javacpp/issues/492))
  * Fix `Parser` producing incorrect calls to function templates with non-type parameters ([issue #491](https://github.com/bytedeco/javacpp/issues/491))
  * Add missing `presets/package-info.java` required for OSGi and add profile for M2Eclipse ([pull #490](https://github.com/bytedeco/javacpp/pull/490))

--- a/src/main/java/org/bytedeco/javacpp/tools/Context.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Context.java
@@ -44,6 +44,7 @@ class Context {
         constName = c.constName;
         constBaseName = c.constBaseName;
         immutable = c.immutable;
+        beanify = c.beanify;
         inaccessible = c.inaccessible;
         objectify = c.objectify;
         virtualize = c.virtualize;
@@ -61,6 +62,7 @@ class Context {
     String constName = null;
     String constBaseName = null;
     boolean immutable = false;
+    boolean beanify = false;
     boolean inaccessible = false;
     boolean objectify = false;
     boolean virtualize = false;

--- a/src/main/java/org/bytedeco/javacpp/tools/Context.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Context.java
@@ -44,8 +44,8 @@ class Context {
         constName = c.constName;
         constBaseName = c.constBaseName;
         immutable = c.immutable;
-        beanify = c.beanify;
         inaccessible = c.inaccessible;
+        beanify = c.beanify;
         objectify = c.objectify;
         virtualize = c.virtualize;
         variable = c.variable;
@@ -62,8 +62,8 @@ class Context {
     String constName = null;
     String constBaseName = null;
     boolean immutable = false;
-    boolean beanify = false;
     boolean inaccessible = false;
+    boolean beanify = false;
     boolean objectify = false;
     boolean virtualize = false;
     Declarator variable = null;

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -53,6 +53,8 @@ public class Info {
         define = i.define;
         enumerate = i.enumerate;
         flatten = i.flatten;
+        immutable = i.immutable;
+        beanify = i.beanify;
         objectify = i.objectify;
         translate = i.translate;
         skip = i.skip;
@@ -97,6 +99,8 @@ public class Info {
     boolean flatten = false;
     /** Disables generation of setters for public data members of a class */
     boolean immutable = false;
+    /** Adds JavaBeans-style prefixes to getters and setters of public data members of a class */
+    boolean beanify = false;
     /** Map global functions to instance methods, without {@code static} modifier, to implement an interface, etc. */
     boolean objectify = false;
     /** Attempts to translate naively the statements of variable-like macros to Java. */
@@ -134,6 +138,8 @@ public class Info {
     public Info flatten(boolean flatten) { this.flatten = flatten; return this; }
     public Info immutable() { this.immutable = true; return this; }
     public Info immutable(boolean immutable) { this.immutable = immutable; return this; }
+    public Info beanify() { this.beanify = true; return this; }
+    public Info beanify(boolean beanify) { this.beanify = beanify; return this; }
     public Info objectify() { this.objectify = true; return this; }
     public Info objectify(boolean objectify) { this.objectify = objectify; return this; }
     public Info translate() { this.translate = true; return this; }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -2573,9 +2573,8 @@ public class Parser {
                 if (context.namespace != null && context.javaName == null) {
                     decl.text += "@Namespace(\"" + context.namespace + "\") ";
                 }
-                final boolean hasMetadcl = metadcl != null && metadcl.cppName != null && metadcl.cppName.length() > 0;
                 String nameAnnotation = "";
-                if (hasMetadcl) {
+                if (metadcl != null && metadcl.cppName != null && metadcl.cppName.length() > 0) {
                     nameAnnotation = metadcl.indices == 0
                             ? "@Name(\"" + metadcl.cppName + "." + shortName + "\") "
                             : "@Name({\"" + metadcl.cppName + "\", \"." + shortName + "\"}) ";
@@ -2584,13 +2583,13 @@ public class Parser {
                 final boolean beanify = context.beanify && indices.isEmpty();
                 String capitalizedJavaName = null;
                 if (beanify) {
-                    if (!hasMetadcl) {
+                    if (nameAnnotation.length() == 0) {
                         nameAnnotation = "@Name(\"" + shortName + "\") ";
                     }
                     capitalizedJavaName = javaName.substring(0, 1).toUpperCase() + javaName.substring(1);
                     javaName = "get" + capitalizedJavaName;
                 }
-                if (hasMetadcl || beanify) {
+                if (nameAnnotation.length() > 0) {
                     dcl.type.annotations = dcl.type.annotations.replaceAll("@Name\\(.*\\) ", "");
                     decl.text += nameAnnotation;
                 }
@@ -2605,10 +2604,11 @@ public class Parser {
                         indices += ", ";
                     }
                     if (beanify) {
-                        decl.text += "\n" + nameAnnotation + "@MemberSetter " + modifiers + setterType + "set" + capitalizedJavaName + "(" + indices + dcl.type.annotations + dcl.type.javaName + " setter);";
+                        decl.text += "\n" + nameAnnotation + "@MemberSetter " + modifiers + setterType + "set" + capitalizedJavaName
+                                  +  "(" + indices + dcl.type.annotations + dcl.type.javaName + " setter);";
                     } else {
                         String javaTypeWithoutAnnotations = dcl.type.javaName.substring(dcl.type.javaName.lastIndexOf(" ") + 1);
-                        decl.text += " " + nameAnnotation + modifiers + setterType + javaName + "(" + indices + javaTypeWithoutAnnotations + " setter);";
+                        decl.text += " " + modifiers + setterType + javaName + "(" + indices + javaTypeWithoutAnnotations + " setter);";
                     }
                 }
                 decl.text += "\n";

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -2573,25 +2573,43 @@ public class Parser {
                 if (context.namespace != null && context.javaName == null) {
                     decl.text += "@Namespace(\"" + context.namespace + "\") ";
                 }
-                if (metadcl != null && metadcl.cppName != null && metadcl.cppName.length() > 0) {
-                    decl.text += metadcl.indices == 0
+                final boolean hasMetadcl = metadcl != null && metadcl.cppName != null && metadcl.cppName.length() > 0;
+                String nameAnnotation = "";
+                if (hasMetadcl) {
+                    nameAnnotation = metadcl.indices == 0
                             ? "@Name(\"" + metadcl.cppName + "." + shortName + "\") "
                             : "@Name({\"" + metadcl.cppName + "\", \"." + shortName + "\"}) ";
-                    dcl.type.annotations = dcl.type.annotations.replaceAll("@Name\\(.*\\) ", "");
                     javaName = metadcl.javaName + "_" + shortName;
                 }
+                final boolean beanify = context.beanify && indices.isEmpty();
+                String capitalizedJavaName = null;
+                if (beanify) {
+                    if (!hasMetadcl) {
+                        nameAnnotation = "@Name(\"" + shortName + "\") ";
+                    }
+                    capitalizedJavaName = javaName.substring(0, 1).toUpperCase() + javaName.substring(1);
+                    javaName = "get" + capitalizedJavaName;
+                }
+                if (hasMetadcl || beanify) {
+                    dcl.type.annotations = dcl.type.annotations.replaceAll("@Name\\(.*\\) ", "");
+                    decl.text += nameAnnotation;
+                }
+                dcl.type.annotations = dcl.type.annotations.replace("@ByVal ", "@ByRef ");
                 final boolean hasSetter = !(dcl.type.constValue && dcl.indirections == 0) && !dcl.constPointer && !dcl.type.constExpr && !context.immutable;
-                if (!hasSetter) {
+                if (!hasSetter || beanify) {
                     decl.text += "@MemberGetter ";
                 }
-                decl.text += modifiers + dcl.type.annotations.replace("@ByVal ", "@ByRef ")
-                          + dcl.type.javaName + " " + javaName + "(" + indices + ");";
+                decl.text += modifiers + dcl.type.annotations + dcl.type.javaName + " " + javaName + "(" + indices + ");";
                 if (hasSetter) {
                     if (indices.length() > 0) {
                         indices += ", ";
                     }
-                    String javaTypeWithoutAnnotations = dcl.type.javaName.substring(dcl.type.javaName.lastIndexOf(" ") + 1);
-                    decl.text += " " + modifiers + setterType + javaName + "(" + indices + javaTypeWithoutAnnotations + " setter);";
+                    if (beanify) {
+                        decl.text += "\n" + nameAnnotation + "@MemberSetter " + modifiers + setterType + "set" + capitalizedJavaName + "(" + indices + dcl.type.annotations + dcl.type.javaName + " setter);";
+                    } else {
+                        String javaTypeWithoutAnnotations = dcl.type.javaName.substring(dcl.type.javaName.lastIndexOf(" ") + 1);
+                        decl.text += " " + nameAnnotation + modifiers + setterType + javaName + "(" + indices + javaTypeWithoutAnnotations + " setter);";
+                    }
                 }
                 decl.text += "\n";
                 if ((dcl.type.constValue || dcl.constPointer || dcl.type.constExpr) && dcl.type.staticMember && indices.length() == 0) {
@@ -3313,6 +3331,8 @@ public class Parser {
                 ctx.virtualize = true;
             if (info.immutable)
                 ctx.immutable = true;
+            if (info.beanify)
+                ctx.beanify = true;
         }
         ctx.baseType = base.cppName;
 


### PR DESCRIPTION
Kotlin's feature of automatic conversion of Java getters/setters to properties requires them to have JavaBeans-style prefixes (unless class is a record). `Parser` doesn't add them which makes classes generated by it to be awkward to use in Kotlin.