### PR TITLE
Add parameter classes to Cache mojo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+ * Add `classOrPackageNames` parameter to `CacheMojo` ([pull #510](https://github.com/bytedeco/javacpp/pull/510))
+
 ### August 2, 2021 version 1.5.6
  * Add missing export to `module-info.java` file for presets package ([pull #508](https://github.com/bytedeco/javacpp/pull/508))
  * Add `@NoException(true)` value to support overriding `virtual noexcept` functions

--- a/src/main/java/org/bytedeco/javacpp/tools/BuildMojo.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/BuildMojo.java
@@ -238,7 +238,7 @@ public class BuildMojo extends AbstractMojo {
     @Parameter(defaultValue = "${plugin}", required = true, readonly = true)
     PluginDescriptor plugin;
 
-    String[] merge(String[] ss, String s) {
+    static String[] merge(String[] ss, String s) {
         if (ss != null && s != null) {
             ss = Arrays.copyOf(ss, ss.length + 1);
             ss[ss.length - 1] = s;

--- a/src/main/java/org/bytedeco/javacpp/tools/CacheMojo.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/CacheMojo.java
@@ -107,7 +107,7 @@ public class CacheMojo extends AbstractMojo {
                 classLoader.addPaths(a.getFile().getAbsolutePath());
             }
 
-	    if (targetClasses == null) 
+	    if (targetClasses == null || targetClasses.length == 0) 
 	      classScanner.addPackage(null, true);
 	    else 
 	      for (String c: targetClasses) 

--- a/src/main/java/org/bytedeco/javacpp/tools/CacheMojo.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/CacheMojo.java
@@ -59,6 +59,9 @@ public class CacheMojo extends AbstractMojo {
     @Parameter(defaultValue = "${plugin}", required = true, readonly = true)
     PluginDescriptor plugin;
 
+    @Parameter(property="classes")
+    String[] targetClasses;
+
     String join(String separator, Iterable<String> strings) {
         String string = "";
         for (String s : strings) {
@@ -103,7 +106,12 @@ public class CacheMojo extends AbstractMojo {
             for (Artifact a : artifacts) {
                 classLoader.addPaths(a.getFile().getAbsolutePath());
             }
-            classScanner.addPackage(null, true);
+
+	    if (targetClasses == null) 
+	      classScanner.addPackage(null, true);
+	    else 
+	      for (String c: targetClasses) 
+	        classScanner.addClassOrPackage(c);
 
             LinkedHashSet<String> packages = new LinkedHashSet<String>();
             for (Class c : classes) {

--- a/src/main/java/org/bytedeco/javacpp/tools/CacheMojo.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/CacheMojo.java
@@ -59,8 +59,8 @@ public class CacheMojo extends AbstractMojo {
     @Parameter(defaultValue = "${plugin}", required = true, readonly = true)
     PluginDescriptor plugin;
 
-    @Parameter(property="classes")
-    String[] targetClasses;
+    @Parameter(property="javacpp.classOrPackageNames")
+    String[] classOrPackageNames;
 
     String join(String separator, Iterable<String> strings) {
         String string = "";
@@ -107,11 +107,11 @@ public class CacheMojo extends AbstractMojo {
                 classLoader.addPaths(a.getFile().getAbsolutePath());
             }
 
-	    if (targetClasses == null || targetClasses.length == 0) 
-	      classScanner.addPackage(null, true);
-	    else 
-	      for (String c: targetClasses) 
-	        classScanner.addClassOrPackage(c);
+            if (classOrPackageNames == null || classOrPackageNames.length == 0)
+                classScanner.addPackage(null, true);
+            else
+                for (String c : classOrPackageNames)
+                    classScanner.addClassOrPackage(c);
 
             LinkedHashSet<String> packages = new LinkedHashSet<String>();
             for (Class c : classes) {

--- a/src/main/java/org/bytedeco/javacpp/tools/CacheMojo.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/CacheMojo.java
@@ -62,6 +62,9 @@ public class CacheMojo extends AbstractMojo {
     @Parameter(property="javacpp.classOrPackageNames")
     String[] classOrPackageNames;
 
+    @Parameter(property="javacpp.classOrPackageName")
+    String classOrPackageName;
+
     String join(String separator, Iterable<String> strings) {
         String string = "";
         for (String s : strings) {
@@ -107,11 +110,15 @@ public class CacheMojo extends AbstractMojo {
                 classLoader.addPaths(a.getFile().getAbsolutePath());
             }
 
-            if (classOrPackageNames == null || classOrPackageNames.length == 0)
+            if ((classOrPackageNames == null || classOrPackageNames.length == 0) &&
+                    classOrPackageName == null)
                 classScanner.addPackage(null, true);
-            else
-                for (String c : classOrPackageNames)
-                    classScanner.addClassOrPackage(c);
+            else {
+                if (classOrPackageNames != null)
+                    for (String c : classOrPackageNames)
+                        classScanner.addClassOrPackage(c);
+                classScanner.addClassOrPackage(classOrPackageName);
+            }
 
             LinkedHashSet<String> packages = new LinkedHashSet<String>();
             for (Class c : classes) {


### PR DESCRIPTION
When using 
```
mvn org.bytedeco:javacpp:cache -Djavacpp.platform=linux-x86_64
```
from a project using, e.g., opencv, the cache plugin walks through all classes in the opencv presets and attempts to load the javacpp-annotated ones.
This will try to load and cache a lot of libraries, potentially from other presets like cpython, while the project may use only a subset of them.
This PR adds a `classes` parameter to limit the scope of the class walk:
```
mvn -Dclasses=org.bytedeco.opencv.global.opencv_core,org.bytedeco.opencv.global.opencv_imgproc org.bytedeco:javacpp:cache -Djavacpp.platform=linux-x86_64
```
Does it make sense ?

There is probably smarter but more complex alternatives, like using jdeps or similar to automatically cache what is actually used by the project.