### PR TITLE
Support directory extraction in modular OSGi runtimes (issue #506)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,19 +96,19 @@
       <optional>true</optional>
     </dependency>
     <!--
-      The OSGi R7 Annotations are build time only and not
+      The OSGi R8 Annotations are build time only and not
       needed at runtime, therefore they can be provided scope
     -->
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.annotation</artifactId>
-      <version>7.0.0</version>
+      <version>8.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
-      <version>7.0.0</version>
+      <version>8.0.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,13 @@
       <version>7.0.0</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
+      <version>7.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <repositories>

--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -524,22 +524,22 @@ public class Loader {
             if (!noSubdir) {
                 cacheSubdir = new File(cacheSubdir, urlFile.getParentFile().getName());
             }
-		} else if (OSGiBundleResourceLoader.isOSGiRuntime()) {
-			// TODO: what happens if this is another URL in a OSGi environment?
-			// I think it is unlikely that is called with URL-schema?!
-			if (!noSubdir) {
-				String subdirName = OSGiBundleResourceLoader.getContainerBundleName(resourceURL);
-				if (subdirName != null) {
-					String parentName = urlFile.getParentFile().toString();
-					if (parentName != null) {
-						subdirName = subdirName + File.separator + parentName;
-					}
-					cacheSubdir = new File(cacheSubdir, subdirName);
-				}
-				size = urlConnection.getContentLengthLong();
-				timestamp = urlConnection.getLastModified();
-			}
-		} else {
+        } else if (OSGiBundleResourceLoader.isOSGiRuntime()) {
+            // TODO: what happens if this is another URL in a OSGi environment?
+            // I think it is unlikely that is called with URL-schema?!
+            if (!noSubdir) {
+                String subdirName = OSGiBundleResourceLoader.getContainerBundleName(resourceURL);
+                if (subdirName != null) {
+                    String parentName = urlFile.getParentFile().toString();
+                    if (parentName != null) {
+                        subdirName = subdirName + File.separator + parentName;
+                    }
+                    cacheSubdir = new File(cacheSubdir, subdirName);
+                }
+                size = urlConnection.getContentLengthLong();
+                timestamp = urlConnection.getLastModified();
+            }
+        } else {
             if (urlFile.exists()) {
                 size = urlFile.length();
                 timestamp = urlFile.lastModified();

--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -766,7 +766,6 @@ public class Loader {
         if (urlConnection instanceof JarURLConnection) {
             JarFile jarFile = ((JarURLConnection) urlConnection).getJarFile();
             JarEntry jarEntry = ((JarURLConnection) urlConnection).getJarEntry();
-            String jarFileName = jarFile.getName();
             String jarEntryName = jarEntry.getName();
             if (!jarEntryName.endsWith("/")) {
                 jarEntryName += "/";
@@ -783,8 +782,7 @@ public class Loader {
                         File file = new File(directoryOrFile, entryName.substring(jarEntryName.length()));
                         if (entry.isDirectory()) {
                             file.mkdirs();
-                        } else if (!cacheDirectory || !file.exists() || file.length() != entrySize
-                                || file.lastModified() != entryTimestamp || !file.equals(file.getCanonicalFile())) {
+                        } else if (!cacheDirectory || isCacheFileCurrent(file, entrySize, entryTimestamp)) {
                             // ... extract it from our resources ...
                             file.delete();
                             String s = resourceURL.toString();
@@ -812,8 +810,7 @@ public class Loader {
                     File file = new File(directoryOrFile, entryName.substring(directoryName.length()));
                     if (entryName.endsWith("/")) { // is directory
                         file.mkdirs();
-                    } else if (!cacheDirectory || !file.exists() || file.length() != entrySize
-                            || file.lastModified() != entryTimestamp || !file.equals(file.getCanonicalFile())) {
+                    } else if (!cacheDirectory || isCacheFileCurrent(file, entrySize, entryTimestamp)) {
                         // ... extract it from our resources ...
                         file.delete();
                         // FIXME: check if directories have to be extracted again?!
@@ -877,6 +874,11 @@ public class Loader {
             }
         }
         return file;
+    }
+
+    private static boolean isCacheFileCurrent(File file, long entrySize, long entryTimestamp) throws IOException {
+        return !file.exists() || file.length() != entrySize || file.lastModified() != entryTimestamp
+                || !file.equals(file.getCanonicalFile());
     }
 
     /** Returns {@code findResources(cls, name, 1)[0]} or null if none. */

--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -55,12 +55,16 @@ import java.util.Properties;
 import java.util.WeakHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+
 import org.bytedeco.javacpp.annotation.Cast;
 import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Platform;
 import org.bytedeco.javacpp.annotation.Raw;
 import org.bytedeco.javacpp.tools.Builder;
 import org.bytedeco.javacpp.tools.Logger;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Version;
 
 /**
  * The Loader contains functionality to load native libraries, but also has a bit
@@ -88,6 +92,18 @@ public class Loader {
             return new ArrayDeque<Class<?>>();
         }
     };
+
+    private static final boolean IS_OSGI_RUNTIME;
+    static {
+        boolean isOSGI;
+        try {
+            Bundle.class.getName();
+            isOSGI = true;
+        } catch (NoClassDefFoundError e) {
+            isOSGI = false;
+        }
+        IS_OSGI_RUNTIME = isOSGI;
+    }
 
     public static class Detector {
         /**
@@ -414,7 +430,7 @@ public class Loader {
      */
     public static File cacheResource(Class cls, String name) throws IOException {
         URL u = findResource(cls, name);
-        return u != null ? cacheResource(u) : null;
+        return u != null ? cacheResource(cls, u, null) : null;
     }
 
     /**
@@ -440,14 +456,14 @@ public class Loader {
         URL[] urls = findResources(cls, name);
         File[] files = new File[urls.length];
         for (int i = 0; i < urls.length; i++) {
-            files[i] = cacheResource(urls[i]);
+            files[i] = cacheResource(cls, urls[i], null);
         }
         return files;
     }
 
     /** Returns {@code cacheResource(resourceUrl, null)} */
     public static File cacheResource(URL resourceURL) throws IOException {
-        return cacheResource(resourceURL, null);
+        return cacheResource(null, resourceURL, null);
     }
     /**
      * Extracts a resource, if the size or last modified timestamp differs from what is in cache,
@@ -462,6 +478,10 @@ public class Loader {
      * @see #cacheDir
      */
     public static File cacheResource(URL resourceURL, String target) throws IOException {
+        return cacheResource(null, resourceURL, target);
+    }
+
+    private static File cacheResource(Class<?> cls, URL resourceURL, String target) throws IOException {
         // Find appropriate subdirectory in cache for the resource ...
         File urlFile;
         String[] splitURL = resourceURL.toString().split("#");
@@ -521,6 +541,21 @@ public class Loader {
             }
             if (!noSubdir) {
                 cacheSubdir = new File(cacheSubdir, urlFile.getParentFile().getName());
+            }
+        } else if (IS_OSGI_RUNTIME && cls != null) {
+            size = urlConnection.getContentLengthLong();
+            timestamp = urlConnection.getLastModified();
+
+            Bundle bundle = FrameworkUtil.getBundle(cls);
+            if (bundle != null) {
+                Version v = bundle.getVersion();
+                String version = v.getMajor() + "." + v.getMinor() + "." + v.getMicro(); // skip qualifier
+                String subdirName = bundle.getSymbolicName() + "_" + version;
+                String parentName = urlFile.getParentFile().toString();
+                if (parentName != null) {
+                    subdirName = subdirName + File.separator + parentName;
+                }
+                cacheSubdir = new File(cacheSubdir, subdirName);
             }
         } else {
             if (urlFile.exists()) {
@@ -654,7 +689,7 @@ public class Loader {
                             logger.debug("Extracting " + resourceURL);
                         }
                         file.delete();
-                        extractResource(resourceURL, file, null, null, true);
+                        extractResource(cls, resourceURL, file, null, null, true);
                         file.setLastModified(timestamp);
                     }
                 } finally {
@@ -692,7 +727,7 @@ public class Loader {
     public static File extractResource(Class cls, String name, File directory,
             String prefix, String suffix) throws IOException {
         URL u = findResource(cls, name);
-        return u != null ? extractResource(u, directory, prefix, suffix) : null;
+        return u != null ? extractResource(cls, u, directory, prefix, suffix, false) : null;
     }
 
     /**
@@ -718,7 +753,7 @@ public class Loader {
         URL[] urls = findResources(cls, name);
         File[] files = new File[urls.length];
         for (int i = 0; i < urls.length; i++) {
-            files[i] = extractResource(urls[i], directory, prefix, suffix);
+            files[i] = extractResource(cls, urls[i], directory, prefix, suffix, false);
         }
         return files;
     }
@@ -726,7 +761,7 @@ public class Loader {
     /** Returns {@code extractResource(resourceURL, directoryOrFile, prefix, suffix, false)}. */
     public static File extractResource(URL resourceURL, File directoryOrFile,
             String prefix, String suffix) throws IOException {
-        return extractResource(resourceURL, directoryOrFile, prefix, suffix, false);
+        return extractResource(null, resourceURL, directoryOrFile, prefix, suffix, false);
     }
 
     /**
@@ -744,11 +779,16 @@ public class Loader {
      */
     public static File extractResource(URL resourceURL, File directoryOrFile,
             String prefix, String suffix, boolean cacheDirectory) throws IOException {
+        return extractResource(null, directoryOrFile, prefix, suffix, cacheDirectory);
+    }
+
+    private static File extractResource(Class cls, URL resourceURL, File directoryOrFile, String prefix, String suffix,
+            boolean cacheDirectory) throws IOException {
         URLConnection urlConnection = resourceURL != null ? resourceURL.openConnection() : null;
+        String resourceURLStr = resourceURL.toString();
         if (urlConnection instanceof JarURLConnection) {
             JarFile jarFile = ((JarURLConnection)urlConnection).getJarFile();
             JarEntry jarEntry = ((JarURLConnection)urlConnection).getJarEntry();
-            String jarFileName = jarFile.getName();
             String jarEntryName = jarEntry.getName();
             if (!jarEntryName.endsWith("/")) {
                 jarEntryName += "/";
@@ -759,9 +799,9 @@ public class Loader {
                 while (entries.hasMoreElements()) {
                     JarEntry entry = entries.nextElement();
                     String entryName = entry.getName();
-                    long entrySize = entry.getSize();
-                    long entryTimestamp = entry.getTime();
                     if (entryName.startsWith(jarEntryName)) {
+                        long entrySize = entry.getSize();
+                        long entryTimestamp = entry.getTime();
                         File file = new File(directoryOrFile, entryName.substring(jarEntryName.length()));
                         if (entry.isDirectory()) {
                             file.mkdirs();
@@ -769,14 +809,43 @@ public class Loader {
                                 || file.lastModified() != entryTimestamp || !file.equals(file.getCanonicalFile())) {
                             // ... extract it from our resources ...
                             file.delete();
-                            String s = resourceURL.toString();
-                            URL u = new URL(s.substring(0, s.indexOf("!/") + 2) + entryName);
-                            file = extractResource(u, file, prefix, suffix);
+                            URL u = new URL(resourceURLStr.substring(0, resourceURLStr.indexOf("!/") + 2) + entryName);
+                            file = extractResource(cls, u, file, prefix, suffix, false);
                         }
                         file.setLastModified(entryTimestamp);
                     }
                 }
                 return directoryOrFile;
+            }
+        }
+        if (IS_OSGI_RUNTIME && cls != null) {
+            // TODO: check if the URL is connected to the given class, respectively obtain
+            // the bundle from the URL.
+            Bundle bundle = FrameworkUtil.getBundle(cls);
+            if (bundle != null) {
+                String path = resourceURL.getPath();
+                Enumeration<URL> entries = bundle.findEntries(path, null, true);
+                if (entries != null && entries.hasMoreElements()) { // a not empty directory
+                    while (entries.hasMoreElements()) {
+                        URL entry = entries.nextElement();
+                        String entryPath = entry.getPath();
+                        URLConnection entryConnection = entry.openConnection();
+                        long entrySize = entryConnection.getContentLengthLong();
+                        long entryTimestamp = entryConnection.getLastModified();
+                        File file = new File(directoryOrFile, entryPath.substring(path.length()));
+                        if (entryPath.endsWith("/")) { // is directory
+                            file.mkdirs();
+                        } else if (!cacheDirectory || !file.exists() || file.length() != entrySize
+                                || file.lastModified() != entryTimestamp || !file.equals(file.getCanonicalFile())) {
+                            // ... extract it from our resources ...
+                            file.delete();
+                            // optimization: pass null-class to not check for directories again
+                            extractResource(null, entry, file, prefix, suffix, false);
+                        }
+                        file.setLastModified(entryTimestamp);
+                    }
+                    return directoryOrFile;
+                }
             }
         }
         InputStream is = urlConnection != null ? urlConnection.getInputStream() : null;
@@ -795,7 +864,7 @@ public class Loader {
                 if (directoryOrFile.isDirectory()) {
                     directory = directoryOrFile;
                     try {
-                        file = new File(directoryOrFile, new File(new URI(resourceURL.toString().split("#")[0])).getName());
+                        file = new File(directoryOrFile, new File(new URI(resourceURLStr.split("#")[0])).getName());
                     } catch (IllegalArgumentException | URISyntaxException ex) {
                         file = new File(directoryOrFile, new File(resourceURL.getPath()).getName());
                     }
@@ -1283,7 +1352,7 @@ public class Loader {
                     for (String preload : preloads) {
                         URL[] urls = findLibrary(cls, p, preload, true);
                         for (URL url : urls) {
-                            File f = cacheResource(url);
+                            File f = cacheResource(cls, url, null);
                             if (f != null) {
                                 f.setExecutable(true);
                                 break;
@@ -1309,7 +1378,7 @@ public class Loader {
                                     f.set(u, filename2);
                                 }
                             }
-                            File f = cacheResource(u);
+                            File f = cacheResource(cls, u, null);
                             if (f != null) {
                                 f.setExecutable(true);
                                 executablePaths.put(e, f.getAbsolutePath());
@@ -1596,7 +1665,7 @@ public class Loader {
                     file = new File(uri);
                 } catch (Exception exc) {
                     // ... extract it from resources into the cache, if necessary ...
-                    File f = cacheResource(url, filename);
+                    File f = cacheResource(cls, url, filename);
                     try {
                         if (f != null) {
                             file = f;

--- a/src/main/java/org/bytedeco/javacpp/tools/OSGiBundleResourceLoader.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/OSGiBundleResourceLoader.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2021-2021 Hannes Wellmann
+ *
+ * Licensed either under the Apache License, Version 2.0, or (at your option)
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation (subject to the "Classpath" exception),
+ * either version 2, or any later version (collectively, the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.gnu.org/licenses/
+ *     http://www.gnu.org/software/classpath/license.html
+ *
+ * or as provided in the LICENSE.txt file that accompanied this code.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bytedeco.javacpp.tools;
+
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Version;
+
+public class OSGiBundleResourceLoader {
+
+	private OSGiBundleResourceLoader() { // static use only
+	}
+
+	public static boolean isOSGiRuntime() {
+		return IS_OSGI_RUNTIME;
+	}
+
+	public static String getContainerBundleName(URL resourceURL) {
+		requireOSGi();
+		return OSGiEnvironmentLoader.getContainerBundleName(resourceURL);
+	}
+
+	public static Enumeration<URL> getBundleDirectoryContent(URL resourceURL) {
+		requireOSGi();
+		return OSGiEnvironmentLoader.getBundleDirectoryContent(resourceURL);
+	}
+
+	private static void requireOSGi() {
+		if (!IS_OSGI_RUNTIME) {
+			throw new IllegalStateException(
+				OSGiBundleResourceLoader.class.getSimpleName() + " must only be used within a OSGi runtime");
+		}
+	}
+
+	private static final Map<String, Long> HOST_2_BUNDLE = new ConcurrentHashMap<String, Long>();
+	private static final boolean IS_OSGI_RUNTIME;
+
+	static {
+		boolean isOSGI;
+		try {
+			Bundle.class.getName();
+			isOSGI = true;
+		} catch (NoClassDefFoundError e) {
+			isOSGI = false;
+		}
+		IS_OSGI_RUNTIME = isOSGI;
+		if (IS_OSGI_RUNTIME) {
+			OSGiEnvironmentLoader.initialize();
+		}
+	}
+
+	private static class OSGiEnvironmentLoader {
+		// Code using OSGi APIs has to be encapsulated into own class
+		// to prevent NoClassDefFoundErrors in OSGi environments
+
+		private static void initialize() {
+			BundleContext context = getBundleContext();
+			if (context != null) {
+				indexAllBundles(context);
+				context.addBundleListener(new BundleListener() {
+					@Override
+					public void bundleChanged(BundleEvent event) {
+						Bundle bundle = event.getBundle();
+						switch (event.getType()) {
+						case BundleEvent.RESOLVED:
+							HOST_2_BUNDLE.put(getBundleURLHost(bundle), bundle.getBundleId());
+							break;
+						case BundleEvent.UNRESOLVED:
+							HOST_2_BUNDLE.remove(getBundleURLHost(bundle));
+							break;
+						default:
+							break;
+						}
+					}
+				});
+				context.addFrameworkListener(new FrameworkListener() {
+					@Override
+					public void frameworkEvent(FrameworkEvent event) {
+						if (event.getType() == FrameworkEvent.PACKAGES_REFRESHED) {
+							HOST_2_BUNDLE.clear();
+							indexAllBundles(getBundleContext());
+							// don't keep a reference on the BundleContext
+						}
+					}
+				});
+			}
+		}
+
+		private static BundleContext getBundleContext() {
+			Bundle bundle = FrameworkUtil.getBundle(OSGiEnvironmentLoader.class);
+			if (bundle != null) {
+				int state = bundle.getState();
+				if (state != Bundle.ACTIVE
+					&& (state == Bundle.INSTALLED || state == Bundle.RESOLVED || state == Bundle.STARTING)) {
+					try {
+						bundle.start();
+					} catch (BundleException e) { // ignore
+					}
+				}
+				if (bundle.getState() == Bundle.ACTIVE) {
+					return bundle.getBundleContext();
+				}
+			}
+			return null;
+		}
+
+		private static void indexAllBundles(BundleContext context) {
+			if (context != null) {
+				for (Bundle bundle : context.getBundles()) {
+					HOST_2_BUNDLE.put(getBundleURLHost(bundle), bundle.getBundleId());
+				}
+			}
+		}
+
+		private static String getBundleURLHost(Bundle bundle) {
+			return bundle.getEntry("/").getHost();
+		}
+
+		private static Bundle getContainerBundle(URL url) {
+			Long bundleId = HOST_2_BUNDLE.get(url.getHost());
+			if (bundleId != null) {
+				BundleContext context = getBundleContext();
+				if (context != null) {
+					return context.getBundle(bundleId);
+				}
+			}
+			return null;
+		}
+
+		public static String getContainerBundleName(URL resourceURL) {
+			Bundle bundle = getContainerBundle(resourceURL);
+			if (bundle != null) {
+				Version v = bundle.getVersion();
+				String version = v.getMajor() + "." + v.getMinor() + "." + v.getMicro(); // skip qualifier
+				return bundle.getSymbolicName() + "_" + version;
+			}
+			return null;
+		}
+
+		public static Enumeration<URL> getBundleDirectoryContent(URL resourceURL) {
+			Bundle bundle = getContainerBundle(resourceURL);
+			if (bundle != null) {
+				return bundle.findEntries(resourceURL.getPath(), null, true);
+			}
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
In order to resolve issue #506 I implemented a solution based on @timothyjward suggestion(https://github.com/bytedeco/javacpp/issues/506#issuecomment-886551437) to support extraction of directories in case javacpp is a bundle in a OSGi runtime.

The indention of this solution is to be independent of a specific OSGi framework implementation.

In contrast to @timothyjward suggestion I used `Bundle.findEntries()` instead of `BundleWiring.listResources()` because it is a bit less code (no need to obtain the BundleWiring) and already gives the desired URLs of all files in the directory and not only the String paths within the bundle (avoids 'manual' URL construction).
Since the javacpp bundles don't have a Bundle-Classpath header specified in their Manifest it defaults to the dot ".", so the bundle-classpath is just the jar content. And since the search for resources is limited to local resources, I think the result should always be the same. In Equinox findEntries() returns a URL using the bundleentry schema instead of bundleresources, but that's not an issue.

I have tested it with Equinox and the cpython javacpp preset and it works quite well.

The only flaw is that the javacpp windows-dll's (I assume it is the same case for linux) are cached twice:
1. in the folder for the `javacpp` bundle
2. in the folder of the `cpython` bundle

The second location is obviously not wanted. I tried to investigate that and I think the reason is that the dll's are loaded a second time in the context of a class of the cpython bundle/preset in `Loader.load(Class, Properties, boolean, String)` when `oldUrls == null || urls.length > 0` is true and urls is not empty.

I think this problem could be avoided if we were able to obtain the bundle from the resource-URLs directly. Then it would be possible to find the containing bundle. But unfortunately I don't know a proper official/API way to do this. If any of you knows one, it is more than welcome.

The only approach I found, that would hopefully work with different OSGi implementations, was to maintain a map of URL-hosts to the corresponding bundle/bundle-id that is filled when the Loader is initialized and also keeps track of installed/uninstalled bundles via a BundleListener.
At least in Equinox the resource-URL's host is always the same for the same bundle. Do you know if this is the case for other OSGi implementations as well?
This as the additional advantage that there is no need to pass a class-argument all the way down. I can submit this approach with separate commit to this PR.