### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
               <value>3</value>
             </property>
           </systemProperties>
+        	<forkCount>1.5C</forkCount>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
