### PR TITLE
Add a no-arg constructor to PointerScope

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/PointerScope.java
+++ b/src/main/java/org/bytedeco/javacpp/PointerScope.java
@@ -73,6 +73,11 @@ public class PointerScope implements AutoCloseable {
         scopeStack.get().push(this);
     }
 
+    /** Creates a new scope accepting all pointer types and pushes itself on the {@link #scopeStack}. */
+    public PointerScope() {
+        this((Class<? extends Pointer>[]) null);
+    }
+
     public Class<? extends Pointer>[] forClasses() {
         return forClasses;
     }

--- a/src/main/java/org/bytedeco/javacpp/PointerScope.java
+++ b/src/main/java/org/bytedeco/javacpp/PointerScope.java
@@ -64,6 +64,11 @@ public class PointerScope implements AutoCloseable {
     /** When set to true, the next call to {@link #close()} does not release but resets this variable. */
     boolean extend = false;
 
+    /** Creates a new scope accepting all pointer types and pushes itself on the {@link #scopeStack}. */
+    public PointerScope() {
+        this((Class<? extends Pointer>[])null);
+    }
+
     /** Initializes {@link #forClasses}, and pushes itself on the {@link #scopeStack}. */
     public PointerScope(Class<? extends Pointer>... forClasses) {
         if (logger.isDebugEnabled()) {
@@ -71,11 +76,6 @@ public class PointerScope implements AutoCloseable {
         }
         this.forClasses = forClasses;
         scopeStack.get().push(this);
-    }
-
-    /** Creates a new scope accepting all pointer types and pushes itself on the {@link #scopeStack}. */
-    public PointerScope() {
-        this((Class<? extends Pointer>[]) null);
     }
 
     public Class<? extends Pointer>[] forClasses() {


### PR DESCRIPTION
What about adding this no-arg constructor to `PointerScope` ?
It's just meant to prevent IDE and compilers to complain about unchecked generic array creation in constructs such as:

```
try (PointerScope ignored = new PointerScope()) {
   ...
}
```