### PR TITLE
Align `maven-core` and `maven-plugin-api` versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
-    <bnd.version>5.3.0</bnd.version>
     <maven.version>3.0</maven.version>
+    <bnd.version>5.3.0</bnd.version>
     <javacpp.platform.root></javacpp.platform.root>
     <javacpp.platform.suffix></javacpp.platform.suffix>
     <javacpp.platform.compiler></javacpp.platform.compiler>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.6.2</version>
+      <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -291,9 +291,9 @@
             </goals>
             <configuration>
               <links>
-                <link>http://maven.apache.org/ref/3.8.4/maven-plugin-api/apidocs</link>
+                <link>http://maven.apache.org/ref/${maven.version}/maven-plugin-api/apidocs</link>
                 <link>http://maven.apache.org/plugin-tools/maven-plugin-annotations/apidocs</link>
-                <link>http://maven.apache.org/ref/3.0/maven-core/apidocs</link>
+                <link>http://maven.apache.org/ref/${maven.version}/maven-core/apidocs</link>
                 <link>http://www.slf4j.org/apidocs</link>
                 <link>http://junit.org/junit4/javadoc/4.13.2</link>
               </links>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
     <bnd.version>5.3.0</bnd.version>
+    <maven.version>3.8.4</maven.version>
     <javacpp.platform.root></javacpp.platform.root>
     <javacpp.platform.suffix></javacpp.platform.suffix>
     <javacpp.platform.compiler></javacpp.platform.compiler>
@@ -68,7 +69,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.8.4</version>
+      <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -80,7 +81,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.0</version>
+      <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
     <bnd.version>5.3.0</bnd.version>
-    <maven.version>3.8.4</maven.version>
+    <maven.version>3.0</maven.version>
     <javacpp.platform.root></javacpp.platform.root>
     <javacpp.platform.suffix></javacpp.platform.suffix>
     <javacpp.platform.compiler></javacpp.platform.compiler>

--- a/src/main/java/org/bytedeco/javacpp/tools/ClearMojo.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/ClearMojo.java
@@ -40,7 +40,7 @@ public class ClearMojo extends AbstractMojo {
         try {
             Loader.clearCacheDir();
         } catch (IOException e) {
-            throw new MojoExecutionException(e.getMessage());
+            throw new MojoExecutionException(e.toString());
         }
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/ClearMojo.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/ClearMojo.java
@@ -40,7 +40,7 @@ public class ClearMojo extends AbstractMojo {
         try {
             Loader.clearCacheDir();
         } catch (IOException e) {
-            throw new MojoExecutionException("Failed to clear cache directory", e);
+            throw new MojoExecutionException(e.getMessage());
         }
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/ClearMojo.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/ClearMojo.java
@@ -40,7 +40,7 @@ public class ClearMojo extends AbstractMojo {
         try {
             Loader.clearCacheDir();
         } catch (IOException e) {
-            throw new MojoExecutionException(e);
+            throw new MojoExecutionException("Failed to clear cache directory", e);
         }
     }
 }


### PR DESCRIPTION
Currently, there are two different versions used for `maven-plugin-api` and `maven-core`. They share a couple of transitive dependencies, and therefore there are conflicts in the dependency tree. Because of that, we need to pin some dependencies in downstream projects. This change aligns their versions.

The current dependency tree:

```
$ mvn dependency:tree -Dverbose
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] 
[INFO] ------------------------< org.bytedeco:javacpp >------------------------
[INFO] Building JavaCPP 1.5.8-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ javacpp ---
[INFO] org.bytedeco:javacpp:jar:1.5.8-SNAPSHOT
[INFO] +- org.apache.maven:maven-plugin-api:jar:3.8.4:provided
[INFO] |  +- org.apache.maven:maven-model:jar:3.8.4:provided
[INFO] |  |  \- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven:maven-artifact:jar:3.8.4:provided
[INFO] |  |  +- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  |  \- org.apache.commons:commons-lang3:jar:3.8.1:provided
[INFO] |  +- org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.3.5:provided
[INFO] |  |  +- javax.annotation:javax.annotation-api:jar:1.2:provided
[INFO] |  |  +- org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.3.5:provided
[INFO] |  |  +- (org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:provided - omitted for duplicate)
[INFO] |  |  +- (org.codehaus.plexus:plexus-classworlds:jar:2.5.2:provided - omitted for conflict with 2.6.0)
[INFO] |  |  \- (org.codehaus.plexus:plexus-utils:jar:3.0.24:provided - omitted for conflict with 3.3.0)
[INFO] |  +- org.codehaus.plexus:plexus-utils:jar:3.3.0:provided
[INFO] |  \- org.codehaus.plexus:plexus-classworlds:jar:2.6.0:provided
[INFO] +- org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.6.2:provided
[INFO] +- org.apache.maven:maven-core:jar:3.0:provided
[INFO] |  +- (org.apache.maven:maven-model:jar:3.0:provided - omitted for conflict with 3.8.4)
[INFO] |  +- org.apache.maven:maven-settings:jar:3.0:provided
[INFO] |  |  \- (org.codehaus.plexus:plexus-utils:jar:2.0.4:provided - omitted for conflict with 3.3.0)
[INFO] |  +- org.apache.maven:maven-settings-builder:jar:3.0:provided
[INFO] |  |  +- (org.codehaus.plexus:plexus-utils:jar:2.0.4:provided - omitted for conflict with 3.3.0)
[INFO] |  |  +- (org.codehaus.plexus:plexus-interpolation:jar:1.14:provided - omitted for duplicate)
[INFO] |  |  +- (org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven:maven-settings:jar:3.0:provided - omitted for duplicate)
[INFO] |  |  \- (org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven:maven-repository-metadata:jar:3.0:provided
[INFO] |  |  \- (org.codehaus.plexus:plexus-utils:jar:2.0.4:provided - omitted for conflict with 3.3.0)
[INFO] |  +- (org.apache.maven:maven-artifact:jar:3.0:provided - omitted for conflict with 3.8.4)
[INFO] |  +- (org.apache.maven:maven-plugin-api:jar:3.0:provided - omitted for conflict with 3.8.4)
[INFO] |  +- org.apache.maven:maven-model-builder:jar:3.0:provided
[INFO] |  |  +- (org.codehaus.plexus:plexus-utils:jar:2.0.4:provided - omitted for conflict with 3.3.0)
[INFO] |  |  +- (org.codehaus.plexus:plexus-interpolation:jar:1.14:provided - omitted for duplicate)
[INFO] |  |  +- (org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:provided - omitted for duplicate)
[INFO] |  |  \- (org.apache.maven:maven-model:jar:3.0:provided - omitted for conflict with 3.8.4)
[INFO] |  +- org.apache.maven:maven-aether-provider:jar:3.0:provided
[INFO] |  |  +- (org.apache.maven:maven-model-builder:jar:3.0:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven:maven-repository-metadata:jar:3.0:provided - omitted for duplicate)
[INFO] |  |  +- (org.sonatype.aether:aether-api:jar:1.7:provided - omitted for duplicate)
[INFO] |  |  +- (org.sonatype.aether:aether-util:jar:1.7:provided - omitted for duplicate)
[INFO] |  |  +- (org.sonatype.aether:aether-impl:jar:1.7:provided - omitted for duplicate)
[INFO] |  |  \- (org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:provided - omitted for duplicate)
[INFO] |  +- org.sonatype.aether:aether-impl:jar:1.7:provided
[INFO] |  |  +- (org.sonatype.aether:aether-api:jar:1.7:provided - omitted for duplicate)
[INFO] |  |  +- org.sonatype.aether:aether-spi:jar:1.7:provided
[INFO] |  |  |  \- (org.sonatype.aether:aether-api:jar:1.7:provided - omitted for duplicate)
[INFO] |  |  \- (org.sonatype.aether:aether-util:jar:1.7:provided - omitted for duplicate)
[INFO] |  +- org.sonatype.aether:aether-api:jar:1.7:provided
[INFO] |  +- org.sonatype.aether:aether-util:jar:1.7:provided
[INFO] |  |  \- (org.sonatype.aether:aether-api:jar:1.7:provided - omitted for duplicate)
[INFO] |  +- org.sonatype.sisu:sisu-inject-plexus:jar:1.4.2:provided
[INFO] |  |  +- (org.codehaus.plexus:plexus-component-annotations:jar:1.5.4:provided - omitted for conflict with 1.5.5)
[INFO] |  |  +- (org.codehaus.plexus:plexus-classworlds:jar:2.2.3:provided - omitted for conflict with 2.6.0)
[INFO] |  |  +- (org.codehaus.plexus:plexus-utils:jar:2.0.5:provided - omitted for conflict with 3.3.0)
[INFO] |  |  \- org.sonatype.sisu:sisu-inject-bean:jar:1.4.2:provided
[INFO] |  |     \- org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7:provided
[INFO] |  +- org.codehaus.plexus:plexus-interpolation:jar:1.14:provided
[INFO] |  +- (org.codehaus.plexus:plexus-utils:jar:2.0.4:provided - omitted for conflict with 3.3.0)
[INFO] |  +- (org.codehaus.plexus:plexus-classworlds:jar:2.2.3:provided - omitted for conflict with 2.6.0)
[INFO] |  +- org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:provided
[INFO] |  \- org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:provided
[INFO] |     +- (org.codehaus.plexus:plexus-utils:jar:1.5.5:provided - omitted for conflict with 3.3.0)
[INFO] |     \- org.sonatype.plexus:plexus-cipher:jar:1.4:provided
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.slf4j:slf4j-simple:jar:1.7.32:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.32:compile
[INFO] \- org.osgi:osgi.annotation:jar:7.0.0:provided
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.625 s
[INFO] Finished at: 2022-07-05T21:54:48+02:00
[INFO] ------------------------------------------------------------------------

```

The dependency tree after this change:
```
$ mvn dependency:tree -Dverbose
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] 
[INFO] ------------------------< org.bytedeco:javacpp >------------------------
[INFO] Building JavaCPP 1.5.8-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ javacpp ---
[INFO] org.bytedeco:javacpp:jar:1.5.8-SNAPSHOT
[INFO] +- org.apache.maven:maven-plugin-api:jar:3.8.4:provided
[INFO] |  +- org.apache.maven:maven-model:jar:3.8.4:provided
[INFO] |  |  \- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven:maven-artifact:jar:3.8.4:provided
[INFO] |  |  +- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  |  \- (org.apache.commons:commons-lang3:jar:3.8.1:provided - omitted for duplicate)
[INFO] |  +- org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.3.5:provided
[INFO] |  |  +- javax.annotation:javax.annotation-api:jar:1.2:provided
[INFO] |  |  +- (org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.3.5:provided - omitted for duplicate)
[INFO] |  |  +- (org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:provided - omitted for conflict with 2.1.0)
[INFO] |  |  +- (org.codehaus.plexus:plexus-classworlds:jar:2.5.2:provided - omitted for conflict with 2.6.0)
[INFO] |  |  \- (org.codehaus.plexus:plexus-utils:jar:3.0.24:provided - omitted for conflict with 3.3.0)
[INFO] |  +- org.codehaus.plexus:plexus-utils:jar:3.3.0:provided
[INFO] |  \- org.codehaus.plexus:plexus-classworlds:jar:2.6.0:provided
[INFO] +- org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.6.2:provided
[INFO] +- org.apache.maven:maven-core:jar:3.8.4:provided
[INFO] |  +- (org.apache.maven:maven-model:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven:maven-settings:jar:3.8.4:provided
[INFO] |  |  \- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven:maven-settings-builder:jar:3.8.4:provided
[INFO] |  |  +- (org.apache.maven:maven-builder-support:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  |  +- (javax.inject:javax.inject:jar:1:provided - omitted for duplicate)
[INFO] |  |  +- (org.codehaus.plexus:plexus-interpolation:jar:1.26:provided - omitted for duplicate)
[INFO] |  |  +- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven:maven-settings:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  |  \- org.codehaus.plexus:plexus-sec-dispatcher:jar:2.0:provided
[INFO] |  |     +- (org.codehaus.plexus:plexus-utils:jar:3.4.1:provided - omitted for conflict with 3.3.0)
[INFO] |  |     +- org.codehaus.plexus:plexus-cipher:jar:2.0:provided
[INFO] |  |     |  \- (javax.inject:javax.inject:jar:1:provided - omitted for duplicate)
[INFO] |  |     \- (javax.inject:javax.inject:jar:1:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven:maven-builder-support:jar:3.8.4:provided
[INFO] |  +- org.apache.maven:maven-repository-metadata:jar:3.8.4:provided
[INFO] |  |  \- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  +- (org.apache.maven:maven-artifact:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  +- (org.apache.maven:maven-plugin-api:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven:maven-model-builder:jar:3.8.4:provided
[INFO] |  |  +- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  |  +- (org.codehaus.plexus:plexus-interpolation:jar:1.26:provided - omitted for duplicate)
[INFO] |  |  +- (javax.inject:javax.inject:jar:1:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven:maven-model:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven:maven-artifact:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven:maven-builder-support:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  |  \- (org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.3.5:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven:maven-resolver-provider:jar:3.8.4:provided
[INFO] |  |  +- (org.apache.maven:maven-model:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven:maven-model-builder:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven:maven-repository-metadata:jar:3.8.4:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven.resolver:maven-resolver-api:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven.resolver:maven-resolver-spi:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven.resolver:maven-resolver-util:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven.resolver:maven-resolver-impl:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  |  +- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  |  \- (javax.inject:javax.inject:jar:1:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven.resolver:maven-resolver-impl:jar:1.6.3:provided
[INFO] |  |  +- (org.apache.maven.resolver:maven-resolver-api:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven.resolver:maven-resolver-spi:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.maven.resolver:maven-resolver-util:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  |  +- (org.apache.commons:commons-lang3:jar:3.8.1:provided - omitted for duplicate)
[INFO] |  |  \- (org.slf4j:slf4j-api:jar:1.7.30:provided - omitted for conflict with 1.7.32)
[INFO] |  +- org.apache.maven.resolver:maven-resolver-api:jar:1.6.3:provided
[INFO] |  +- org.apache.maven.resolver:maven-resolver-spi:jar:1.6.3:provided
[INFO] |  |  \- (org.apache.maven.resolver:maven-resolver-api:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven.resolver:maven-resolver-util:jar:1.6.3:provided
[INFO] |  |  \- (org.apache.maven.resolver:maven-resolver-api:jar:1.6.3:provided - omitted for duplicate)
[INFO] |  +- org.apache.maven.shared:maven-shared-utils:jar:3.3.4:provided
[INFO] |  |  \- commons-io:commons-io:jar:2.6:provided
[INFO] |  +- (org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.3.5:provided - omitted for duplicate)
[INFO] |  +- org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.3.5:provided
[INFO] |  +- com.google.inject:guice:jar:no_aop:4.2.2:provided
[INFO] |  |  +- (javax.inject:javax.inject:jar:1:provided - omitted for duplicate)
[INFO] |  |  +- aopalliance:aopalliance:jar:1.0:provided
[INFO] |  |  \- com.google.guava:guava:jar:25.1-android:provided
[INFO] |  |     +- com.google.code.findbugs:jsr305:jar:3.0.2:provided
[INFO] |  |     +- org.checkerframework:checker-compat-qual:jar:2.0.0:provided
[INFO] |  |     +- com.google.errorprone:error_prone_annotations:jar:2.1.3:provided
[INFO] |  |     +- com.google.j2objc:j2objc-annotations:jar:1.1:provided
[INFO] |  |     \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:provided
[INFO] |  +- javax.inject:javax.inject:jar:1:provided
[INFO] |  +- (org.codehaus.plexus:plexus-utils:jar:3.3.0:provided - omitted for duplicate)
[INFO] |  +- (org.codehaus.plexus:plexus-classworlds:jar:2.6.0:provided - omitted for duplicate)
[INFO] |  +- org.codehaus.plexus:plexus-interpolation:jar:1.26:provided
[INFO] |  +- org.codehaus.plexus:plexus-component-annotations:jar:2.1.0:provided
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.8.1:provided
[INFO] |  \- (org.slf4j:slf4j-api:jar:1.7.32:compile - scope updated from provided; omitted for duplicate)
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.slf4j:slf4j-simple:jar:1.7.32:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.32:compile
[INFO] \- org.osgi:osgi.annotation:jar:7.0.0:provided
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.671 s
[INFO] Finished at: 2022-07-05T22:18:42+02:00
[INFO] ------------------------------------------------------------------------

```

There are also conflicts in `org.codehaus.plexus:*` and `slf4j-api`, but one step at a time. :)