### PR TITLE
Fix building with clang 15 on OSX #609

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Generator` compiler errors on Mac for Clang without Objective-C support ([pull #610](https://github.com/bytedeco/javacpp/pull/610))
  * Prevent `Parser` from outputting cast methods for base classes that are `Info.skip` ([pull #607](https://github.com/bytedeco/javacpp/pull/607))
  * Ensure `Generator` and `Parser` process header files from `cinclude` before `include` ([issue #580](https://github.com/bytedeco/javacpp/issues/580))
  * Remove `sun.misc.Unsafe` config incompatible/unneeded with GraalVM Native Image 22.x ([issue bytedeco/sample-projects#63](https://github.com/bytedeco/sample-projects/issues/63))

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -315,6 +315,8 @@ public class Generator {
         out.println("#elif defined(__APPLE__) && defined(__OBJC__)");
         out.println("    #include <TargetConditionals.h>");
         out.println("    #include <Foundation/Foundation.h>");
+        out.println("#elif defined(__APPLE__)");
+        out.println("    #include <TargetConditionals.h>");
         out.println("#endif");
         out.println();
         out.println("#ifdef __linux__");


### PR DESCRIPTION
The problem is explained in the issue, but to reiterate: 

Newer versions of apple's clang will error if there is an undefined reference to TARGET_OS_*. The solution to this is to include the `TargetConditionals.h` file ahead of any references. The problem originates here: 

https://github.com/bytedeco/javacpp/blob/f77f8d77f3724128bc26440d930b786892c58312/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L313-L318

The `TargetConditionals.h` is only included if both `__APPLE__` and `__OBJC__` are definied.  If you use a brew installed llvm (currently version 15), the `__APPLE__` will be defined but `__OBJC__` is not. 

What I have done is made it so that `TargetConditionals.h` is always included on apple, and the `Foundation/Foundation.h` is only included when `__OBJC__` is defined. The result is this:

```cpp
#ifdef __ANDROID__
    #include <android/log.h>
#elif defined(__APPLE__)
    #include <TargetConditionals.h>
#endif

#if defined(__OBJC__) 
    #include <Foundation/Foundation.h>
#endif
```

I've tested this on OSX 12.6, clang 15 (installed via `brew install llvm`).