### PR TITLE
Add support for friend functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add `Info.friendly` to have `Parser` map some `friend` functions to Java methods ([pull #649](https://github.com/bytedeco/javacpp/pull/649))
  * Add `Loader.loadProperties(boolean forceReload)` to reset platform properties ([issue deepjavalibrary/djl#2318](https://github.com/deepjavalibrary/djl/issues/2318))
  * Prevent `TokenIndexer` from recursively expanding macros
  * Fix `Generator` passing empty `String` objects on callback for arguments using adapters

--- a/src/main/java/org/bytedeco/javacpp/tools/DeclarationList.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/DeclarationList.java
@@ -38,6 +38,7 @@ class DeclarationList extends ArrayList<Declaration> {
     ListIterator<Info> infoIterator = null;
     String spacing = null;
     DeclarationList inherited = null;
+    ArrayList<Declaration> nonMemberDeclarations = new ArrayList<>();
 
     DeclarationList() { }
     DeclarationList(DeclarationList inherited) {
@@ -60,9 +61,9 @@ class DeclarationList extends ArrayList<Declaration> {
     }
 
     @Override public boolean add(Declaration decl) {
-        return add(decl, null);
+        return add(decl, null, false);
     }
-    public boolean add(Declaration decl, String fullName) {
+    public boolean add(Declaration decl, String fullName, boolean notMember) {
         boolean add = true;
         if (templateMap != null && templateMap.empty() && !decl.custom && (decl.type != null || decl.declarator != null)) {
             // method templates cannot be declared in Java, but make sure to make their
@@ -192,8 +193,12 @@ class DeclarationList extends ArrayList<Declaration> {
                 }
             }
             if (!found) {
-                decl.text = rescan(decl.text);
-                super.add(decl);
+                if (notMember)
+                    nonMemberDeclarations.add(decl);
+                else {
+                    decl.text = rescan(decl.text);
+                    super.add(decl);
+                }
                 add = true;
             }
         }

--- a/src/main/java/org/bytedeco/javacpp/tools/DeclarationList.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/DeclarationList.java
@@ -38,7 +38,6 @@ class DeclarationList extends ArrayList<Declaration> {
     ListIterator<Info> infoIterator = null;
     String spacing = null;
     DeclarationList inherited = null;
-    ArrayList<Declaration> nonMemberDeclarations = new ArrayList<>();
 
     DeclarationList() { }
     DeclarationList(DeclarationList inherited) {
@@ -61,9 +60,9 @@ class DeclarationList extends ArrayList<Declaration> {
     }
 
     @Override public boolean add(Declaration decl) {
-        return add(decl, null, false);
+        return add(decl, null);
     }
-    public boolean add(Declaration decl, String fullName, boolean notMember) {
+    public boolean add(Declaration decl, String fullName) {
         boolean add = true;
         if (templateMap != null && templateMap.empty() && !decl.custom && (decl.type != null || decl.declarator != null)) {
             // method templates cannot be declared in Java, but make sure to make their
@@ -193,12 +192,8 @@ class DeclarationList extends ArrayList<Declaration> {
                 }
             }
             if (!found) {
-                if (notMember)
-                    nonMemberDeclarations.add(decl);
-                else {
-                    decl.text = rescan(decl.text);
-                    super.add(decl);
-                }
+                decl.text = rescan(decl.text);
+                super.add(decl);
                 add = true;
             }
         }

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -95,9 +95,8 @@ public class Info {
     /** Maps native C++ {@code enum} classes to Java {@code enum} types, along with methods using them.
      * To use as keys in maps, etc, intern() must be called on instances returned from native code. */
     boolean enumerate = false;
-    /** Maps friend functions (that are not also declared outside the class, so only accessible through ADL)
-     * as global static methods. Only functions taking an instance of the class as one of their arguments are
-     * currently supported. */
+    /** Maps friend functions. Only functions having in their argument list an instance of the class they are friend
+     * of are currently supported. They are mapped as instance methods of the class. */
     boolean mapFriends = false;
     /** Outputs declarations for this class into their subclasses as well.
      * Also adds methods for explicit casting, as done for multiple inheritance by default. */

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -52,8 +52,8 @@ public class Info {
         cast = i.cast;
         define = i.define;
         enumerate = i.enumerate;
-        mapFriends = i.mapFriends;
         flatten = i.flatten;
+        friendly = i.friendly;
         immutable = i.immutable;
         beanify = i.beanify;
         objectify = i.objectify;
@@ -95,12 +95,12 @@ public class Info {
     /** Maps native C++ {@code enum} classes to Java {@code enum} types, along with methods using them.
      * To use as keys in maps, etc, intern() must be called on instances returned from native code. */
     boolean enumerate = false;
-    /** Maps friend functions. Only functions having in their argument list an instance of the class they are friend
-     * of are currently supported. They are mapped as instance methods of the class. */
-    boolean mapFriends = false;
     /** Outputs declarations for this class into their subclasses as well.
      * Also adds methods for explicit casting, as done for multiple inheritance by default. */
     boolean flatten = false;
+    /** Maps friend functions. Only functions having in their argument list an instance of the class they are friend
+     * of are currently supported. They are mapped as instance methods of the class. */
+    boolean friendly = false;
     /** Disables generation of setters for public data members of a class */
     boolean immutable = false;
     /** Adds JavaBeans-style prefixes to getters and setters of public data members of a class */
@@ -138,10 +138,10 @@ public class Info {
     public Info define(boolean define) { this.define = define; return this; }
     public Info enumerate() { this.enumerate = true; return this; }
     public Info enumerate(boolean enumerate) { this.enumerate = enumerate; return this; }
-    public Info mapFriends() { this.mapFriends = true; return this; }
-    public Info mapFriends(boolean mapFriends) { this.mapFriends = mapFriends; return this; }
     public Info flatten() { this.flatten = true; return this; }
     public Info flatten(boolean flatten) { this.flatten = flatten; return this; }
+    public Info friendly() { this.friendly = true; return this; }
+    public Info friendly(boolean friendly) { this.friendly = friendly; return this; }
     public Info immutable() { this.immutable = true; return this; }
     public Info immutable(boolean immutable) { this.immutable = immutable; return this; }
     public Info beanify() { this.beanify = true; return this; }

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -52,6 +52,7 @@ public class Info {
         cast = i.cast;
         define = i.define;
         enumerate = i.enumerate;
+        mapFriends = i.mapFriends;
         flatten = i.flatten;
         immutable = i.immutable;
         beanify = i.beanify;
@@ -94,6 +95,10 @@ public class Info {
     /** Maps native C++ {@code enum} classes to Java {@code enum} types, along with methods using them.
      * To use as keys in maps, etc, intern() must be called on instances returned from native code. */
     boolean enumerate = false;
+    /** Maps friend functions (that are not also declared outside the class, so only accessible through ADL)
+     * as global static methods. Only functions taking an instance of the class as one of their arguments are
+     * currently supported. */
+    boolean mapFriends = false;
     /** Outputs declarations for this class into their subclasses as well.
      * Also adds methods for explicit casting, as done for multiple inheritance by default. */
     boolean flatten = false;
@@ -134,6 +139,8 @@ public class Info {
     public Info define(boolean define) { this.define = define; return this; }
     public Info enumerate() { this.enumerate = true; return this; }
     public Info enumerate(boolean enumerate) { this.enumerate = enumerate; return this; }
+    public Info mapFriends() { this.mapFriends = true; return this; }
+    public Info mapFriends(boolean mapFriends) { this.mapFriends = mapFriends; return this; }
     public Info flatten() { this.flatten = true; return this; }
     public Info flatten(boolean flatten) { this.flatten = flatten; return this; }
     public Info immutable() { this.immutable = true; return this; }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -2332,8 +2332,16 @@ public class Parser {
                 break;
             }
         }
-        if (tokens.get().match("&&") || (context.javaName == null && localNamespace > 0) || (info != null && info.skip)) {
-            // this is a rvalue function, or a member function definition or specialization, skip over
+        Info info2 = infoMap.getFirst(null);
+        boolean mapFriends = info != null ? info.mapFriends : info2 != null ? info2.mapFriends : false;
+        if (tokens.get().match("&&")
+                || (context.javaName == null && localNamespace > 0)
+                || (info != null && info.skip)
+                || (type.friend && !mapFriends)
+        ) {
+            // this is a rvalue function, or a member function definition or specialization,
+            // or a friend function and we don't want to map it,
+            // skip over
             while (!tokens.get().match(':', '{', ';', Token.EOF)) {
                 tokens.next();
             }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3670,11 +3670,11 @@ public class Parser {
             info.javaText = decl.text;
         }
         if (declList.add(decl)) {
-            for (Declaration dd: declList2.nonMemberDeclarations) {
+            for (Declaration friendDecl: declList2.nonMemberDeclarations) {
                 // Only add the friend functions that we know will be visible through ADL.
-                for (int i=0; i<dd.declarator.parameters.declarators.length; i++)
-                    if (dd.declarator.parameters.declarators[i].type.cppName.equals(type.cppName)) {
-                        globalDeclList.add(dd);
+                for (Declarator paramDecl: friendDecl.declarator.parameters.declarators)
+                    if (paramDecl.type.cppName.equals(type.cppName)) {
+                        globalDeclList.add(friendDecl);
                         break;
                     }
             }

--- a/src/main/java/org/bytedeco/javacpp/tools/Type.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Type.java
@@ -50,4 +50,12 @@ class Type {
             return false;
         }
     }
+
+    String signature() {
+        String sig = "";
+        for (char c : javaName.substring(javaName.lastIndexOf(' ') + 1).toCharArray()) {
+            sig += Character.isJavaIdentifierPart(c) ? c : '_';
+        }
+        return sig;
+    }
 }


### PR DESCRIPTION
This PR is a proposal to add support for friend functions to the parser.
Currently, these functions are simply ignored.

Friend functions are non-member functions but are declared in a class body. They have access to the class private and protected members.

This PR does the following:
1) When a friend function is parsed, instead of being added to the current list of declarations, it’s added to a special list of non-member declarations.
2) When we finish parsing an entire group, and if the declaration of the group has been successfully added to the parent declaration list, we also add the non-members declarations to the global declaration list.

Tested on Pytorch : this patch allows to map about 25 functions that were missing, and doesn’t alter anything else. Most of these functions are operator overloads. The generated new JNI code compiles, baring the removal of [this info](https://github.com/bytedeco/javacpp-presets/blob/a48eb57460d452825473410fd3cc3c870716203f/pytorch/src/main/java/org/bytedeco/pytorch/presets/torch.java#L2076). It corresponds to a template instantiation apparently not meant to exist. Any idea why it was added ? The second infoMap `c10::Dict<c10::Ivalue,c10::Ivalue>::iterator` is correct.

One minor caveat:
C++ allows operators to be declared either as friend functions or as member functions, e.g.:
```c++
struct Foo {
    private:
      int n;
    public:
      Foo(int x) {
        n=x;
      }
      bool operator<=(Foo& rhs) {
        return n <= rhs.n;
      }
   friend bool operator<(Foo& lhs,  Foo& rhs) {
     return lhs.n < rhs.n
   }
};
```
In both case, the C++ user will write the same operation : `x < y` or `x ≤ y` but in Java it will map as an instance method `x.lessThanEquals(y)` and as a static method `lessThan(x, y)`. Not a big deal.

Another caveat is about accessibility: C++ has some complicated rules for locating a function in the tree of namespaces based on the type of the arguments: the ADL (argument-dependent lookup).
```c++
namespace ns {
  struct Bar {
    …
  };
  struct Foo {
    friend bool operator<(Foo& lhs, Foo& rhs) { … }
    friend bool operator<(Bar& lhs, Bar& rhs) { … }
  };
}
```
in the exampe above,  `x < y ` works if x and y are Foo, but not it they are Bar, because the declaration of < on Bars cannot be found from type Bar. Ideally the first operator must be mapped to Java, because it is accessible, but not the second one.
In this PR we map the function only if it has an argument of the same type that the one it’s declared in. That covers only a subset of the ADL and some theoretically accessible friend functions could be missed.
