### PR TITLE
Fix output path when provided classes have same length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Builder` default output path for class names with the same length ([pull #654](https://github.com/bytedeco/javacpp/pull/654))
  * Add `Info.friendly` to have `Parser` map some `friend` functions to Java methods ([pull #649](https://github.com/bytedeco/javacpp/pull/649))
  * Add `Loader.loadProperties(boolean forceReload)` to reset platform properties ([issue deepjavalibrary/djl#2318](https://github.com/deepjavalibrary/djl/issues/2318))
  * Prevent `TokenIndexer` from recursively expanding macros

--- a/src/main/java/org/bytedeco/javacpp/tools/Builder.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Builder.java
@@ -481,9 +481,8 @@ public class Builder {
                     String resourceURL2 = Loader.findResource(classes[i], resourceName2).toString();
                     String packageURI2 = resourceURL2.substring(0, resourceURL2.lastIndexOf('/') + 1);
 
-                    String longest, shortest;
-                    if (packageURI2.length() > packageURI.length()) { longest = packageURI2; shortest = packageURI; }
-                    else { longest = packageURI; shortest = packageURI2; }
+                    String longest = packageURI2.length() >= packageURI.length() ? packageURI2 : packageURI;
+                    String shortest = packageURI2.length() < packageURI.length() ? packageURI2 : packageURI;
                     while (!longest.startsWith(shortest) && shortest.lastIndexOf('/') > 0) {
                         shortest = shortest.substring(0, shortest.lastIndexOf('/'));
                     }

--- a/src/main/java/org/bytedeco/javacpp/tools/Builder.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Builder.java
@@ -449,7 +449,7 @@ public class Builder {
     /**
      * Creates and returns the directory where output files should be placed.
      * Uses {@link #outputDirectory} as is when available, but falls back
-     * on the shortest common path to the classes as well as the platform
+     * on the longest common path to the classes as well as the platform
      * specific library path when available, or the platform name itself
      * and the user provided extension when not.
      *
@@ -476,13 +476,14 @@ public class Builder {
                 String resourceURL = Loader.findResource(classes[0], resourceName).toString();
                 String packageURI = resourceURL.substring(0, resourceURL.lastIndexOf('/') + 1);
                 for (int i = 1; i < classes.length; i++) {
-                    // Use shortest common package name among all classes as default output path
+                    // Use the longest common package name among all classes as default output path
                     String resourceName2 = '/' + classes[i].getName().replace('.', '/')  + ".class";
                     String resourceURL2 = Loader.findResource(classes[i], resourceName2).toString();
                     String packageURI2 = resourceURL2.substring(0, resourceURL2.lastIndexOf('/') + 1);
 
-                    String longest = packageURI2.length() > packageURI.length() ? packageURI2 : packageURI;
-                    String shortest = packageURI2.length() < packageURI.length() ? packageURI2 : packageURI;
+                    String longest, shortest;
+                    if (packageURI2.length() > packageURI.length()) { longest = packageURI2; shortest = packageURI; }
+                    else { longest = packageURI; shortest = packageURI2; }
                     while (!longest.startsWith(shortest) && shortest.lastIndexOf('/') > 0) {
                         shortest = shortest.substring(0, shortest.lastIndexOf('/'));
                     }


### PR DESCRIPTION
If `getOutputPath` is provided 2 classes with same path length, `longest` and `shortest` are assigned the same value, and the returned path is one of the 2 full path (depending on their order in the input array).
This PR fixes that (+ a typo in comment).