### PR TITLE
Copy declarations between classes

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Builder.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Builder.java
@@ -449,7 +449,7 @@ public class Builder {
     /**
      * Creates and returns the directory where output files should be placed.
      * Uses {@link #outputDirectory} as is when available, but falls back
-     * on the longest common path to the classes as well as the platform
+     * on the shortest common path to the classes as well as the platform
      * specific library path when available, or the platform name itself
      * and the user provided extension when not.
      *
@@ -476,14 +476,13 @@ public class Builder {
                 String resourceURL = Loader.findResource(classes[0], resourceName).toString();
                 String packageURI = resourceURL.substring(0, resourceURL.lastIndexOf('/') + 1);
                 for (int i = 1; i < classes.length; i++) {
-                    // Use the longest common package name among all classes as default output path
+                    // Use shortest common package name among all classes as default output path
                     String resourceName2 = '/' + classes[i].getName().replace('.', '/')  + ".class";
                     String resourceURL2 = Loader.findResource(classes[i], resourceName2).toString();
                     String packageURI2 = resourceURL2.substring(0, resourceURL2.lastIndexOf('/') + 1);
 
-                    String longest, shortest;
-                    if (packageURI2.length() > packageURI.length()) { longest = packageURI2; shortest = packageURI; }
-                    else { longest = packageURI; shortest = packageURI2; }
+                    String longest = packageURI2.length() > packageURI.length() ? packageURI2 : packageURI;
+                    String shortest = packageURI2.length() < packageURI.length() ? packageURI2 : packageURI;
                     while (!longest.startsWith(shortest) && shortest.lastIndexOf('/') > 0) {
                         shortest = shortest.substring(0, shortest.lastIndexOf('/'));
                     }

--- a/src/main/java/org/bytedeco/javacpp/tools/Builder.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Builder.java
@@ -449,7 +449,7 @@ public class Builder {
     /**
      * Creates and returns the directory where output files should be placed.
      * Uses {@link #outputDirectory} as is when available, but falls back
-     * on the shortest common path to the classes as well as the platform
+     * on the longest common path to the classes as well as the platform
      * specific library path when available, or the platform name itself
      * and the user provided extension when not.
      *
@@ -476,13 +476,14 @@ public class Builder {
                 String resourceURL = Loader.findResource(classes[0], resourceName).toString();
                 String packageURI = resourceURL.substring(0, resourceURL.lastIndexOf('/') + 1);
                 for (int i = 1; i < classes.length; i++) {
-                    // Use shortest common package name among all classes as default output path
+                    // Use the longest common package name among all classes as default output path
                     String resourceName2 = '/' + classes[i].getName().replace('.', '/')  + ".class";
                     String resourceURL2 = Loader.findResource(classes[i], resourceName2).toString();
                     String packageURI2 = resourceURL2.substring(0, resourceURL2.lastIndexOf('/') + 1);
 
-                    String longest = packageURI2.length() > packageURI.length() ? packageURI2 : packageURI;
-                    String shortest = packageURI2.length() < packageURI.length() ? packageURI2 : packageURI;
+                    String longest, shortest;
+                    if (packageURI2.length() > packageURI.length()) { longest = packageURI2; shortest = packageURI; }
+                    else { longest = packageURI; shortest = packageURI2; }
                     while (!longest.startsWith(shortest) && shortest.lastIndexOf('/') > 0) {
                         shortest = shortest.substring(0, shortest.lastIndexOf('/'));
                     }

--- a/src/main/java/org/bytedeco/javacpp/tools/Context.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Context.java
@@ -71,6 +71,7 @@ class Context {
     TemplateMap templateMap = null;
     List<String> usingList = null;
     Map<String,String> namespaceMap = null;
+    CopiedDeclarations copiedDeclarations;
 
     /** Return all likely combinations of namespaces and template arguments for this C++ type */
     String[] qualify(String cppName) {

--- a/src/main/java/org/bytedeco/javacpp/tools/CopiedDeclarations.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/CopiedDeclarations.java
@@ -1,0 +1,23 @@
+package org.bytedeco.javacpp.tools;
+
+import java.util.ArrayList;
+
+class CopiedDeclarations extends ArrayList<CopiedDeclarations.CopiedDeclaration> {
+    void add(Declaration decl, String fullname, String modifiers, String namespace) {
+        add(new CopiedDeclaration(decl, fullname, modifiers, namespace));
+    }
+
+    static class CopiedDeclaration {
+        final Declaration decl;
+        final String fullname;
+        final String modifiers;
+        final String namespace;
+
+        CopiedDeclaration(Declaration decl, String fullname, String modifiers, String namespace) {
+            this.decl = decl;
+            this.fullname = fullname;
+            this.modifiers = modifiers;
+            this.namespace = namespace;
+        }
+    }
+}

--- a/src/main/java/org/bytedeco/javacpp/tools/CopiedDeclarations.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/CopiedDeclarations.java
@@ -3,8 +3,8 @@ package org.bytedeco.javacpp.tools;
 import java.util.ArrayList;
 
 class CopiedDeclarations extends ArrayList<CopiedDeclarations.CopiedDeclaration> {
-    void add(Declaration decl, String fullname, String modifiers, String namespace) {
-        add(new CopiedDeclaration(decl, fullname, modifiers, namespace));
+    void add(Declaration decl, String fullname, String modifiers, Context context) {
+        add(new CopiedDeclaration(decl, fullname, modifiers, context.namespace, context.templateMap));
     }
 
     static class CopiedDeclaration {
@@ -12,12 +12,14 @@ class CopiedDeclarations extends ArrayList<CopiedDeclarations.CopiedDeclaration>
         final String fullname;
         final String modifiers;
         final String namespace;
+        final TemplateMap templateMap;
 
-        CopiedDeclaration(Declaration decl, String fullname, String modifiers, String namespace) {
+        CopiedDeclaration(Declaration decl, String fullname, String modifiers, String namespace, TemplateMap templateMap) {
             this.decl = decl;
             this.fullname = fullname;
             this.modifiers = modifiers;
             this.namespace = namespace;
+            this.templateMap = templateMap;
         }
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Declaration.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Declaration.java
@@ -26,7 +26,7 @@ package org.bytedeco.javacpp.tools;
  *
  * @author Samuel Audet
  */
-class Declaration {
+class Declaration implements Cloneable {
     Type type = null;
     Declarator declarator = null;
     boolean abstractMember = false, constMember = false, inaccessible = false,
@@ -35,5 +35,15 @@ class Declaration {
 
     public String toString() {
         return text;
+    }
+
+    @Override
+    public Declaration clone() {
+        try {
+            // Shallow copy is enough for the current usage
+            return (Declaration) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Declaration.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Declaration.java
@@ -26,24 +26,33 @@ package org.bytedeco.javacpp.tools;
  *
  * @author Samuel Audet
  */
-class Declaration implements Cloneable {
+class Declaration {
     Type type = null;
     Declarator declarator = null;
     boolean abstractMember = false, constMember = false, inaccessible = false,
             incomplete = false, function = false, variable = false, comment = false, custom = false;
     String signature = "", text = "";
 
-    public String toString() {
-        return text;
+    public Declaration() {
     }
 
-    @Override
-    public Declaration clone() {
-        try {
-            // Shallow copy is enough for the current usage
-            return (Declaration) super.clone();
-        } catch (CloneNotSupportedException e) {
-            throw new AssertionError();
-        }
+    Declaration(Declaration src) {
+        // Shallow copy is enough for the current usage
+        type = src.type;
+        declarator = src.declarator;
+        abstractMember = src.abstractMember;
+        constMember = src.constMember;
+        inaccessible = src.inaccessible;
+        incomplete = src.incomplete;
+        function = src.function;
+        variable = src.variable;
+        comment = src.comment;
+        custom = src.custom;
+        signature = src.signature;
+        text = src.text;
+    }
+
+    public String toString() {
+        return text;
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -131,12 +131,6 @@ public class Info {
     String javaText = null;
     /** List of cpp names (class, struct, member function) the declarations of which we want to copy in this class or struct. */
     List<String> copyFrom = null;
-    /** If not-null, declarations for these cpp names are copied.
-     * Set to non-null by InfoMap.normalizeCopy or for polymorphic classes. */
-    CopiedDeclarations copiedDeclarations = null;
-    /** Set by Parser when a class has a virtual member function or inherit from a polymorphic class. */
-    boolean polymorphic = false;
-
 
     public Info cppNames(String... cppNames) { this.cppNames = cppNames; return this; }
     public Info javaNames(String... javaNames) { this.javaNames = javaNames; return this; }

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -27,6 +27,10 @@ import org.bytedeco.javacpp.annotation.ByVal;
 import org.bytedeco.javacpp.annotation.Cast;
 import org.bytedeco.javacpp.annotation.Virtual;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Holds information useful to the {@link Parser} and associated with C++ identifiers.
  * Info objects are meant to be added by the user to an {@link InfoMap} passed as
@@ -65,6 +69,7 @@ public class Info {
         base = i.base;
         cppText = i.cppText;
         javaText = i.javaText;
+        copyFrom = i.copyFrom == null ? null : new ArrayList<>(i.copyFrom);
     }
 
     /** A list of C++ identifiers, expressions, or header filenames to which this info is to be bound.
@@ -124,6 +129,14 @@ public class Info {
     String cppText = null;
     /** Outputs the given code, instead of the result parsed from the declaration of C++ identifiers. */
     String javaText = null;
+    /** List of cpp names (class, struct, member function) the declarations of which we want to copy in this class or struct. */
+    List<String> copyFrom = null;
+    /** If not-null, declarations for these cpp names are copied.
+     * Set to non-null by InfoMap.normalizeCopy or for polymorphic classes. */
+    CopiedDeclarations copiedDeclarations = null;
+    /** Set by Parser when a class has a virtual member function or inherit from a polymorphic class. */
+    boolean polymorphic = false;
+
 
     public Info cppNames(String... cppNames) { this.cppNames = cppNames; return this; }
     public Info javaNames(String... javaNames) { this.javaNames = javaNames; return this; }
@@ -161,4 +174,5 @@ public class Info {
     public Info base(String base) { this.base = base; return this; }
     public Info cppText(String cppText) { this.cppText = cppText; return this; }
     public Info javaText(String javaText) { this.javaText = javaText; return this; }
+    public Info copyFrom(String... cppNames) { this.copyFrom = Arrays.asList(cppNames); return this; }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashSet;
 
 /**
  * A {@link Map} containing {@link Info} objects consumed by the {@link Parser}.
@@ -345,22 +344,4 @@ public class InfoMap extends HashMap<String,List<Info>> {
         return put(0, info);
     }
 
-    /** Initialize copiedDeclarations for cppName we need to copy declarations from. */
-    void normalizeCopy() {
-        HashSet<String> copyFrom = new HashSet<>();
-        for (List<Info> infoList: values()) {
-            for (Info i: infoList) {
-                if (i.copyFrom != null)
-                    copyFrom.addAll(i.copyFrom);
-            }
-        }
-        for (String cppName: copyFrom) {
-            Info i = getFirst(cppName);
-            if (i == null) {
-                i = new Info(cppName);
-                put(i);
-            }
-            i.copiedDeclarations = new CopiedDeclarations();
-        }
-    }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
 
 /**
  * A {@link Map} containing {@link Info} objects consumed by the {@link Parser}.
@@ -342,5 +343,24 @@ public class InfoMap extends HashMap<String,List<Info>> {
 
     public InfoMap putFirst(Info info) {
         return put(0, info);
+    }
+
+    /** Initialize copiedDeclarations for cppName we need to copy declarations from. */
+    void normalizeCopy() {
+        HashSet<String> copyFrom = new HashSet<>();
+        for (List<Info> infoList: values()) {
+            for (Info i: infoList) {
+                if (i.copyFrom != null)
+                    copyFrom.addAll(i.copyFrom);
+            }
+        }
+        for (String cppName: copyFrom) {
+            Info i = getFirst(cppName);
+            if (i == null) {
+                i = new Info(cppName);
+                put(i);
+            }
+            i.copiedDeclarations = new CopiedDeclarations();
+        }
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -2638,9 +2638,9 @@ public class Parser {
                         CopiedDeclarations cd = copiedDeclarations.get(type.constructor ?
                                 dcl.cppName + "::" + dcl.cppName.substring(namespace + 2) :
                                 dcl.cppName);
-                        if (cd != null) cd.add(decl, fullname, modifiers, context.namespace);
+                        if (cd != null) cd.add(decl, fullname, modifiers, context);
                         if (context.copiedDeclarations != null && !type.constructor)
-                            context.copiedDeclarations.add(decl, fullname, modifiers, context.namespace);
+                            context.copiedDeclarations.add(decl, fullname, modifiers, context);
                     }
                 }
                 if (type.virtual && context.virtualize) {
@@ -3611,6 +3611,7 @@ public class Parser {
                         d.text += modifiers + d.declarator.type.annotations + context.shorten(d.declarator.type.javaName) + " " + d.declarator.javaName + d.declarator.parameters.list + ";\n";
                     }
 
+                    declList2.templateMap = cd.templateMap;
                     declList2.add(d, cd.fullname);
                 }
             }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3603,7 +3603,9 @@ public class Parser {
                                 modifiers += ann + " ";
                         }
                     }
-                    if (d.declarator.type != null && d.declarator.type.constructor) {
+                    if (infoCopyTo != null && infoCopyTo.javaText != null)
+                        d.text = "\n" + infoCopyTo.javaText;
+                    else if (d.declarator.type != null && d.declarator.type.constructor) {
                         Parameters params = d.declarator.parameters;
                         d.text = "\npublic " + shortName + params.list + " { super((Pointer)null); allocate" + params.names + "; }\n" +
                                 d.declarator.type.annotations + "private native void allocate" + params.list + ";\n";

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3575,7 +3575,7 @@ public class Parser {
                 // Adjust @Virtual
                 // Probably other modifications are necessary.
                 for (CopiedDeclarations.CopiedDeclaration cd : infoCopyFrom.copiedDeclarations) {
-                    Declaration d = cd.decl.clone();
+                    Declaration d = new Declaration(cd.decl);
                     final String funcName = (d.declarator.type != null && d.declarator.type.constructor) ?
                             shortName : ctx.shorten(d.declarator.javaName);
                     Info infoCopyTo = infoMap.getFirst(ctx.namespace == null ? funcName : ctx.namespace + "::" + funcName);


### PR DESCRIPTION
This PR adds a mechanism to copy declarations from one class to another.
It is used automatically when a virtual inheritance towards a polymorphic class, that we cannot transpose to Java, is detected (see #651).
We can also copy on-demand with a new `Info.copyFrom`. This is useful for instance when a C++ API forwards calls to another class. Example with Pytorch:
```Java
.put(new Info("torch::nn::Linear").copyFrom("torch::nn::LinarImpl::LinearImpl", "torch::nn::LinearImpl::forward"))
.put(new Info("torch::nn::Linear::forward").annotations("@Name(\"operator()\")"))        
```
copies the constructors and the forward method from `LinearImpl` to `Linear`, whatever their arguments are.
We also map the new forward method to the `operator()` that does the C++ forwarding.

There is already the `flatten` info that replaces the inheritance of a superclass to all its subclasses by a copy of the declarations. It's not really the declarations that are copied, but the whole java text of the class, after a string
replacement of the superclass name by the subclass name. The string replacement has good chance to break things like annotations, and there is no check for duplicate declarations after the copy. This PR keeps `flatten()` for compatibility but I'm not sure it's a good idea, because of its limits and because the code of Parser would be simpler if we merged this feature with the new copy mechanism. Is `flatten()` used (it is not in the current bytedeco presets) ? In which case ?

Limit: the headers must be parsed in order from superclasses to subclasses for the detection of polymorphic classes to work. Also the classes we copy from must be parsed before the classes we copy to.

Possible breakage: only in the case of virtual inheritance of a polymorphic class. The new style flattening will be triggered automatically.

Still work in progress because more tests are needed.
Also I didn't bother yet with indentation of copied declaration or with copy of comments attached to declarations.