### PR TITLE
Fix namespaces and template arguments parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Use regex in `Parser` to match more robustly templates and namespaces ([pull #657](https://github.com/bytedeco/javacpp/pull/657))
  * Fix `Builder` default output path for class names with the same length ([pull #654](https://github.com/bytedeco/javacpp/pull/654))
  * Add `Info.friendly` to have `Parser` map some `friend` functions to Java methods ([pull #649](https://github.com/bytedeco/javacpp/pull/649))
  * Add `Loader.loadProperties(boolean forceReload)` to reset platform properties ([issue deepjavalibrary/djl#2318](https://github.com/deepjavalibrary/djl/issues/2318))

--- a/src/main/java/org/bytedeco/javacpp/tools/Context.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Context.java
@@ -90,6 +90,7 @@ class Context {
         }
         List<String> names = new ArrayList<String>();
         String ns = namespace != null ? namespace : "";
+        String prefix = infoMap.normalize(cppName, false, true);
         while (ns != null) {
             String name = ns.length() > 0 ? ns + "::" + cppName : cppName;
             if (parameters != null && name.endsWith(parameters)) {
@@ -118,7 +119,6 @@ class Context {
             names.add(name);
 
             for (String s : usingList) {
-                String prefix = infoMap.normalize(cppName, false, true);
                 int i = s.lastIndexOf("::") + 2;
                 String ns2 = ns.length() > 0 ? ns + "::" + s.substring(0, i) : s.substring(0, i);
                 String suffix = s.substring(i);

--- a/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
@@ -230,13 +230,13 @@ public class InfoMap extends HashMap<String,List<Info>> {
                     break;
                 }
             }
-            for (int i = 0; i < parameters; i++) {
-                if (i > lastColon && tokens[i].match('<')) {
+            for (int i = lastColon + 1; i < parameters; i++) {
+                if (tokens[i].match('<')) {
                     if (count == 0) {
                         template = i;
                     }
                     count++;
-                } else if (i > lastColon && tokens[i].match('>')) {
+                } else if (tokens[i].match('>')) {
                     count--;
                     if (count == 0 && i + 1 != parameters) {
                         template = -1;

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3200,9 +3200,8 @@ public class Parser {
         String cppName = dcl.type.cppName;
         String baseType = context.baseType;
         if (baseType != null) {
-            boolean noTemplate = Templates.strip(cppName).length() == cppName.length();
             String baseTypeStripped = Templates.strip(baseType);
-            if (noTemplate && cppName.startsWith(baseTypeStripped)) {
+            if (Templates.notExists(cppName) && cppName.startsWith(baseTypeStripped)) {
                 cppName = baseType + cppName.substring(baseTypeStripped.length());
             }
         }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -141,7 +141,7 @@ public class Parser {
         return s;
     }
 
-    private boolean noTemplate(String s) {
+    private static boolean noTemplate(String s) {
         return templateStrip(s).length() == s.length();
     }
 

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3401,28 +3401,23 @@ public class Parser {
         }
 
         boolean isQualified = namespaceSplit(type.cppName).size() > 1;
-        if (type.cppName.length() > 0 && context.namespace != null && !isQualified) {
+        if (context.namespace != null && !isQualified) {
             type.cppName = context.namespace + "::" + type.cppName;
             originalName = context.namespace + "::" + originalName;
         }
-        Info info;
-        if (type.cppName.length() == 0)
-            info = null;
-        else {
-            info = infoMap.getFirst(type.cppName);
-            if (((info == null || info.base == null) && skipBase) || (info != null && info.skip)) {
-                decl.text = "";
-                declList.add(decl);
-                return true;
-            } else if (info != null && info.pointerTypes != null && info.pointerTypes.length > 0) {
-                type.javaName = context.constName != null ? context.constName : info.pointerTypes[0].substring(info.pointerTypes[0].lastIndexOf(" ") + 1);
-                name = context.shorten(type.javaName);
-            } else if (info == null && !friend) {
-                if (type.javaName.length() > 0 && context.javaName != null) {
-                    type.javaName = context.javaName + "." + type.javaName;
-                }
-                infoMap.put(info = new Info(type.cppName).pointerTypes(type.javaName));
+        Info info = infoMap.getFirst(type.cppName);
+        if (((info == null || info.base == null) && skipBase) || (info != null && info.skip)) {
+            decl.text = "";
+            declList.add(decl);
+            return true;
+        } else if (info != null && info.pointerTypes != null && info.pointerTypes.length > 0) {
+            type.javaName = context.constName != null ? context.constName : info.pointerTypes[0].substring(info.pointerTypes[0].lastIndexOf(" ") + 1);
+            name = context.shorten(type.javaName);
+        } else if (info == null && !friend) {
+            if (type.javaName.length() > 0 && context.javaName != null) {
+                type.javaName = context.javaName + "." + type.javaName;
             }
+            infoMap.put(info = new Info(type.cppName).pointerTypes(type.javaName));
         }
         Type base = new Type("Pointer");
         Iterator<Type> it = baseClasses.iterator();

--- a/src/main/java/org/bytedeco/javacpp/tools/Templates.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Templates.java
@@ -1,0 +1,52 @@
+package org.bytedeco.javacpp.tools;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+abstract class Templates {
+
+  static final private Pattern templatePattern = Pattern.compile("<[^<>=]*>");
+
+  // Remove template arguments from s, taking care of nested templates, default arguments (xxx<>), operator <=>, ->, etc...
+  static String strip(String s) {
+      Matcher m;
+      do {
+          m = templatePattern.matcher(s);
+          s = m.replaceFirst("");
+      } while (!m.hitEnd());
+      return s;
+  }
+
+  static boolean hasNone(String s) {
+      return strip(s).length() == s.length();
+  }
+
+  // Split s at ::, but taking care of qualified template arguments
+  static List<String> nsSplit(String s) {
+      String sTemplatesMasked = s;
+      for (;;) {
+          Matcher m = templatePattern.matcher(sTemplatesMasked);
+          if (m.find()) {
+              char[] c = new char[m.end() - m.start()];
+              Arrays.fill(c, '.');
+              sTemplatesMasked = sTemplatesMasked.substring(0, m.start()) + new String(c) + sTemplatesMasked.substring(m.end());
+          } else
+              break;
+      }
+      ArrayList<String> comps = new ArrayList<>();
+      int start = 0;
+      for (;;) {
+          int i = sTemplatesMasked.indexOf("::", start);
+          if (i >= 0) {
+              comps.add(s.substring(start, i));
+              start = i + 2;
+          } else
+              break;
+      }
+      comps.add(s.substring(start));
+      return comps;
+  }
+}

--- a/src/main/java/org/bytedeco/javacpp/tools/Templates.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Templates.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2023 Hervé Guillemet
+ *
+ * Licensed either under the Apache License, Version 2.0, or (at your option)
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation (subject to the "Classpath" exception),
+ * either version 2, or any later version (collectively, the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.gnu.org/licenses/
+ *     http://www.gnu.org/software/classpath/license.html
+ *
+ * or as provided in the LICENSE.txt file that accompanied this code.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bytedeco.javacpp.tools;
 
 import java.util.ArrayList;
@@ -6,47 +28,50 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-abstract class Templates {
+class Templates {
 
-  static final private Pattern templatePattern = Pattern.compile("<[^<>=]*>");
+    static final Pattern templatePattern = Pattern.compile("<[^<>=]*>");
 
-  // Remove template arguments from s, taking care of nested templates, default arguments (xxx<>), operator <=>, ->, etc...
-  static String strip(String s) {
-      Matcher m;
-      do {
-          m = templatePattern.matcher(s);
-          s = m.replaceFirst("");
-      } while (!m.hitEnd());
-      return s;
-  }
+    /** Remove template arguments from s, taking care of nested templates, default arguments (xxx<>), operator <=>, ->, etc... */
+    static String strip(String s) {
+        Matcher m;
+        do {
+            m = templatePattern.matcher(s);
+            s = m.replaceFirst("");
+        } while (!m.hitEnd());
+        return s;
+    }
 
-  static boolean hasNone(String s) {
-      return strip(s).length() == s.length();
-  }
+    /** Returns {@code strip(s).length() == s.length()}. */
+    static boolean notExists(String s) {
+        return strip(s).length() == s.length();
+    }
 
-  // Split s at ::, but taking care of qualified template arguments
-  static List<String> nsSplit(String s) {
-      String sTemplatesMasked = s;
-      for (;;) {
-          Matcher m = templatePattern.matcher(sTemplatesMasked);
-          if (m.find()) {
-              char[] c = new char[m.end() - m.start()];
-              Arrays.fill(c, '.');
-              sTemplatesMasked = sTemplatesMasked.substring(0, m.start()) + new String(c) + sTemplatesMasked.substring(m.end());
-          } else
-              break;
-      }
-      ArrayList<String> comps = new ArrayList<>();
-      int start = 0;
-      for (;;) {
-          int i = sTemplatesMasked.indexOf("::", start);
-          if (i >= 0) {
-              comps.add(s.substring(start, i));
-              start = i + 2;
-          } else
-              break;
-      }
-      comps.add(s.substring(start));
-      return comps;
-  }
+    /** Split s at ::, but taking care of qualified template arguments */
+    static List<String> splitNamespace(String s) {
+        String sTemplatesMasked = s;
+        for (;;) {
+            Matcher m = templatePattern.matcher(sTemplatesMasked);
+            if (m.find()) {
+                char[] c = new char[m.end() - m.start()];
+                Arrays.fill(c, '.');
+                sTemplatesMasked = sTemplatesMasked.substring(0, m.start()) + new String(c) + sTemplatesMasked.substring(m.end());
+            } else {
+                break;
+            }
+        }
+        ArrayList<String> comps = new ArrayList<>();
+        int start = 0;
+        for (;;) {
+            int i = sTemplatesMasked.indexOf("::", start);
+            if (i >= 0) {
+                comps.add(s.substring(start, i));
+                start = i + 2;
+            } else {
+                break;
+            }
+        }
+        comps.add(s.substring(start));
+        return comps;
+    }
 }


### PR DESCRIPTION
At various places, the parser uses simple character searchs like `indexOf('<')`  to find templates arguments, or namespace components. This PR replaces this with more robust searchs that should work in all cases like nested templates, `operator<`, namespace-qualified template arguments etc...

Also add a couple of minor improvements.

More details below.

