### PR TITLE
Add Info.defaultInsertable

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -65,6 +65,7 @@ public class Info {
         base = i.base;
         cppText = i.cppText;
         javaText = i.javaText;
+        defaultInsertable = i.defaultInsertable;
     }
 
     /** A list of C++ identifiers, expressions, or header filenames to which this info is to be bound.
@@ -124,6 +125,10 @@ public class Info {
     String cppText = null;
     /** Outputs the given code, instead of the result parsed from the declaration of C++ identifiers. */
     String javaText = null;
+    /** If a type is not DefaultInsertable (has no default constructor), containers with this value type won't try to implement resize(). */
+    boolean defaultInsertable = true;
+
+
 
     public Info cppNames(String... cppNames) { this.cppNames = cppNames; return this; }
     public Info javaNames(String... javaNames) { this.javaNames = javaNames; return this; }
@@ -161,4 +166,6 @@ public class Info {
     public Info base(String base) { this.base = base; return this; }
     public Info cppText(String cppText) { this.cppText = cppText; return this; }
     public Info javaText(String javaText) { this.javaText = javaText; return this; }
+    public Info notDefaultInsertable() { this.defaultInsertable = false; return this; }
+    public Info defaultInsertable(boolean di) { this.defaultInsertable = di; return this; }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -171,6 +171,10 @@ public class Parser {
                     indexType.cppName = "size_t";
                     indexType.javaName = "long";
                     valueType = containerType.arguments[0];
+                    if (resizable) {
+                        Info valueInfo = infoMap.getFirst(valueType.cppName);
+                        resizable = valueInfo == null || valueInfo.defaultInsertable;
+                    }
                 }
                 String indexFunction = "(function = \"at\")";
                 String iteratorType = "iterator";


### PR DESCRIPTION
Add a new Info to hint that a class cannot be default-constructed in containers.

WIthout this PR, some containers cannot be mapped to Java because the Parser will generate a `resize` method that is not supported.

Seen in pytorch for things like `std::vector<torch::OrderedDict<std::string,std::shared_ptr<torch::nn::Module>>::Item>` or `std::vector<torch::nn::AnyValue>`.