### PR TITLE
Fix template substitution with const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Parser` incorrectly mapping `const` pointers to template arguments of pointer types ([pull #677](https://github.com/bytedeco/javacpp/pull/677))
  * Fix `Parser` with `Info.enumerate` failing to translate `enum` values based on other `enum` values
  * Fix `Parser` prematurely expanding macros defined in `class`, `struct` or `union` ([issue #674](https://github.com/bytedeco/javacpp/issues/674))
  * Add `Info.upcast` to support class hierarchies with virtual inheritance ([pull #671](https://github.com/bytedeco/javacpp/pull/671))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
- * Fix `Parser` incorrectly mapping `const` pointers to template arguments of pointer types ([pull #677](https://github.com/bytedeco/javacpp/pull/677))
+ * Fix `Parser` incorrectly casting `const` pointers to template arguments of pointer types ([pull #677](https://github.com/bytedeco/javacpp/pull/677))
  * Fix `Parser` with `Info.enumerate` failing to translate `enum` values based on other `enum` values
  * Fix `Parser` prematurely expanding macros defined in `class`, `struct` or `union` ([issue #674](https://github.com/bytedeco/javacpp/issues/674))
  * Add `Info.upcast` to support class hierarchies with virtual inheritance ([pull #671](https://github.com/bytedeco/javacpp/pull/671))

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -908,7 +908,7 @@ public class Parser {
                 type.constValue = false;
             } else if (type.constValue) {
                 type.constValue = false;
-                type.constPointer = true;
+                type.constPointer = true; // For good measure. constPointer is ignored in this case.
             }
             type.cppName = type.cppName.substring(0, type.cppName.length() - 1);
         }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -906,6 +906,9 @@ public class Parser {
             type.indirections++;
             if (type.reference) {
                 type.constValue = false;
+            } else if (type.constValue) {
+                type.constValue = false;
+                type.constPointer = true;
             }
             type.cppName = type.cppName.substring(0, type.cppName.length() - 1);
         }


### PR DESCRIPTION
```c++
template <typename T>
class X {
 public:
    X(const T*) {}
};
```

If you instantiate this template with `int *`, then the resulting type should be `int * const *` and not `const int **`.  
But the parser produces this, with a `new Info("X<int *>").pointerTypes("XI")`:
``` Java
    public XI(@Cast("const int**") PointerPointer arg0) { super((Pointer)null); allocate(arg0); }
    private native void allocate(@Cast("const int**") PointerPointer arg0);
```
Leading to JNI compile error since the constructor expects a `int * const*`.
This PR tries to fix this. It seems to do the trick. The parser now emits:
``` Java
    public XI(@Cast("int**") PointerPointer arg0) { super((Pointer)null); allocate(arg0); }
    private native void allocate(@Cast("int**") PointerPointer arg0);
```
The `const` doesn't appear in the cast at all, but at least we have a better chance to compile the JNI.
I'm not sure it generalizes well. Can we do something better ?