### PR TITLE
Fix parsing of friend simple-type-specifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Parser` failing on some `friend` functions for `operator` overloading ([pull #681](https://github.com/bytedeco/javacpp/pull/681))
  * Fix `Parser` incorrectly casting `const` pointers to template arguments of pointer types ([pull #677](https://github.com/bytedeco/javacpp/pull/677))
  * Fix `Parser` with `Info.enumerate` failing to translate `enum` values based on other `enum` values
  * Fix `Parser` prematurely expanding macros defined in `class`, `struct` or `union` ([issue #674](https://github.com/bytedeco/javacpp/issues/674))

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3359,7 +3359,7 @@ public class Parser {
             return false;
         }
         if (!tokens.get().match('{') && tokens.get(1).match(Token.IDENTIFIER)
-                && !tokens.get(1).match(Token.FINAL)
+                && !tokens.get(1).match(Token.FINAL) && !friend
                 && (typedef || !tokens.get(2).match(';'))) {
             tokens.next();
         }


### PR DESCRIPTION
```c++
class B {
  friend bool operator<( B x, B y) { return true; }
}
```
Fails to parse with an `Unexpected token 'EOF'`.

In `group`, `friend`, not followed by `class`/`struct`/`union`, is assumed to be a C++11 friendship declaration with a simple-type-specifier.
`bool` is skipped, probably taken for some attributes, and a call to `type` on `operator <` throws the exception because it looks for template arguments until end of file.
This PR proposes a fix by never skipping the token after `friend`, so `type` will parse what is expected to be a type (`bool` in this case, instead of `operator`). I think that what needs to be skipped (attributes ?) only concerns non-friend declaration.

No changes in parsing for existing presets, but in Pytorch, where an addition declaration (`ptr_to_first_element`) is added in `global.java`. Without the PR, parsing of `List.h` ends prematurely because of a `friend bool operator<`.

Allows to parse `intrusive_ptr.h` in Pytorch.