### PR TITLE
Add removeVariadic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Have `Parser` desugar `...` varargs to array `[]` for return types as well ([pull #682](https://github.com/bytedeco/javacpp/pull/682))
  * Fix `Parser` failing on some `friend` functions for `operator` overloading ([pull #681](https://github.com/bytedeco/javacpp/pull/681))
  * Fix `Parser` incorrectly casting `const` pointers to template arguments of pointer types ([pull #677](https://github.com/bytedeco/javacpp/pull/677))
  * Fix `Parser` with `Info.enumerate` failing to translate `enum` values based on other `enum` values

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -102,8 +102,8 @@ public class Parser {
         return s.substring(s.lastIndexOf(' ') + 1);
     }
 
-    static String removeVariadic(String s) {
-        return s.endsWith("...") ?  s.substring(0, s.length()-3) + "[]" : s;
+    static String desugarVarargs(String s) {
+        return s.trim().endsWith("...") ? s.trim().substring(0, s.length() - 3) + "[]" : s;
     }
 
     static String upcastMethodName(String javaName) {
@@ -2523,7 +2523,7 @@ public class Parser {
                     extraDecl = new Declaration();
                     extraDecl.signature = signature;
                     extraDecl.declarator = dcl; // Used in group to recognize friends
-                    extraDecl.text = "public " + removeVariadic(dcl.type.javaName) + " " + dcl.javaName + "(" + argList + ") { "
+                    extraDecl.text = "public " + desugarVarargs(dcl.type.javaName) + " " + dcl.javaName + "(" + argList + ") { "
                               + (dcl.type.javaName.equals("void") ? "" : "return ") + dcl.javaName + "(" + staticArgList + "); }\n";
                 } else {
                     friendly = false;
@@ -2601,13 +2601,13 @@ public class Parser {
                         sb.append(removeAnnotations(param.type.javaName)).append(" ").append(param.javaName);
                     }
                     decl.text += accessModifier + " " + (staticMethod ? "static " : "")
-                              +  removeVariadic(removeAnnotations(type.javaName)) + " " + dcl.javaName + "(" + sb + ") { "
+                              +  desugarVarargs(removeAnnotations(type.javaName)) + " " + dcl.javaName + "(" + sb + ") { "
                               +  (type.javaName.equals("void") ? "" : "return ")
                               +  (context.upcast && !staticMethod ? upcastMethodName(context.javaName) + "()." : "")
                               +  "_" + dcl.javaName + (dcl.parameters.names == null ? "()" : dcl.parameters.names) + "; }\n";
                     dcl.javaName = "_" + dcl.javaName;
                 }
-                decl.text += modifiers2 + type.annotations + context.shorten(removeVariadic(type.javaName)) + " " + dcl.javaName + dcl.parameters.list + ";\n";
+                decl.text += modifiers2 + type.annotations + context.shorten(desugarVarargs(type.javaName)) + " " + dcl.javaName + dcl.parameters.list + ";\n";
             }
             decl.signature = dcl.signature;
 

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -102,6 +102,10 @@ public class Parser {
         return s.substring(s.lastIndexOf(' ') + 1);
     }
 
+    static String removeVariadic(String s) {
+        return s.endsWith("...") ?  s.substring(0, s.length()-3) + "[]" : s;
+    }
+
     static String upcastMethodName(String javaName) {
         String shortName = javaName.substring(javaName.lastIndexOf('.') + 1);
         return "as" + Character.toUpperCase(shortName.charAt(0)) + shortName.substring(1);
@@ -2519,7 +2523,7 @@ public class Parser {
                     extraDecl = new Declaration();
                     extraDecl.signature = signature;
                     extraDecl.declarator = dcl; // Used in group to recognize friends
-                    extraDecl.text = "public " + dcl.type.javaName + " " + dcl.javaName + "(" + argList + ") { "
+                    extraDecl.text = "public " + removeVariadic(dcl.type.javaName) + " " + dcl.javaName + "(" + argList + ") { "
                               + (dcl.type.javaName.equals("void") ? "" : "return ") + dcl.javaName + "(" + staticArgList + "); }\n";
                 } else {
                     friendly = false;
@@ -2597,13 +2601,13 @@ public class Parser {
                         sb.append(removeAnnotations(param.type.javaName)).append(" ").append(param.javaName);
                     }
                     decl.text += accessModifier + " " + (staticMethod ? "static " : "")
-                              +  removeAnnotations(type.javaName) + " " + dcl.javaName + "(" + sb + ") { "
+                              +  removeVariadic(removeAnnotations(type.javaName)) + " " + dcl.javaName + "(" + sb + ") { "
                               +  (type.javaName.equals("void") ? "" : "return ")
                               +  (context.upcast && !staticMethod ? upcastMethodName(context.javaName) + "()." : "")
                               +  "_" + dcl.javaName + (dcl.parameters.names == null ? "()" : dcl.parameters.names) + "; }\n";
                     dcl.javaName = "_" + dcl.javaName;
                 }
-                decl.text += modifiers2 + type.annotations + context.shorten(type.javaName) + " " + dcl.javaName + dcl.parameters.list + ";\n";
+                decl.text += modifiers2 + type.annotations + context.shorten(removeVariadic(type.javaName)) + " " + dcl.javaName + dcl.parameters.list + ";\n";
             }
             decl.signature = dcl.signature;
 


### PR DESCRIPTION
It may be convenient to map a C++ type to a Java variadic, like a `long...`, for method arguments, but then if a C++ function returns this type, the parser will generate illegal code.

This PR replaces the variadic with an array in returned type.
