### PR TITLE
Fix parsing of functions parameters in template arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Parser` for function parameters contained in template arguments ([pull #693](https://github.com/bytedeco/javacpp/pull/693))
  * Fix `Parser` on function pointer declarations starting with `typedef struct` ([pull bytedeco/javacpp-presets#1361](https://github.com/bytedeco/javacpp-presets/pull/1361))
 
 ### June 6, 2023 version 1.5.9

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -638,6 +638,42 @@ public class Parser {
             Type type = type(context);
             arguments.add(type);
             token = tokens.get();
+            if (token.match('(')) {
+                Parameters p = parameters(context, 0, false);
+                if (p != null) {
+                    // Build prototype string, without space after comma
+                    type.cppName += '(';
+                    String separator = "";
+                    for (Declarator d: p.declarators) {
+                        if (d != null) {
+                            String s = d.type.cppName;
+                            if (d.type.constValue && !s.startsWith("const ")) {
+                                s = "const " + s;
+                            }
+                            for (int i = 0; i < d.indirections; i++) {
+                                s += "*";
+                            }
+                            if (d.reference) {
+                                s += "&";
+                            }
+                            if (d.rvalue) {
+                                s += "&&";
+                            }
+                            if (d.type.constPointer && !s.endsWith(" const")) {
+                                s = s + " const";
+                            }
+                            type.cppName += separator + s;
+                            separator = ",";
+                        }
+                    }
+                    type.cppName += ')';
+                    token = tokens.get();
+                    if (token.match('<')) {
+                        tokens.next();
+                        token = tokens.get();
+                    }
+                }
+            }
             if (!token.match(',', '>') && type != null) {
                 // may not actually be a type
                 int count = 0;

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -642,9 +642,9 @@ public class Parser {
                 Parameters p = parameters(context, 0, false);
                 if (p != null) {
                     // Build prototype string, without space after comma
-                    type.cppName += '(';
+                    type.cppName += "(";
                     String separator = "";
-                    for (Declarator d: p.declarators) {
+                    for (Declarator d : p.declarators) {
                         if (d != null) {
                             String s = d.type.cppName;
                             if (d.type.constValue && !s.startsWith("const ")) {
@@ -666,7 +666,7 @@ public class Parser {
                             separator = ",";
                         }
                     }
-                    type.cppName += ')';
+                    type.cppName += ")";
                     token = tokens.get();
                     if (token.match('<')) {
                         // probably an actual less than, skip.

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -669,6 +669,7 @@ public class Parser {
                     type.cppName += ')';
                     token = tokens.get();
                     if (token.match('<')) {
+                        // probably an actual less than, skip.
                         tokens.next();
                         token = tokens.get();
                     }


### PR DESCRIPTION
This PR proposes to call `parameters` from `templateArguments` when a function is found in order to correctly pass its prototype.

This solves  two issues: the parsing of argument identifiers when present, and the resolution of namespaces.

Example:

```c++
namespace ns {
  struct S {
    int x;
  };

  std::function<void(int a)> a;
  std::function<S(S)> b;
}
```
Before, parsed as:
```
std::function<void(inta)>
std::function<ns::S(S)>
```
with the PR:
```
std::function<void(int)>
std::function<ns::S(ns::S)>
```
Some presets need to be adjusted to parse correctly with this PR (fixing of `std::function` parameters):
* 4 mappings in current pytorch
* 2 in opencv
* 1 in onnx

No changes in other presets.
Not tested: libfreenect2, chilitags,hyperscan, tensorflow, ale, ngraph, qt, skia, videoinput, tritonserver, depthai
