### PR TITLE
Add info to store iterator mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Let `Parser` map iterators of basic containers systematically ([pull #694](https://github.com/bytedeco/javacpp/pull/694))
  * Fix `Parser` for function parameters contained in template arguments ([pull #693](https://github.com/bytedeco/javacpp/pull/693))
  * Fix `Parser` on function pointer declarations starting with `typedef struct` ([pull bytedeco/javacpp-presets#1361](https://github.com/bytedeco/javacpp-presets/pull/1361))
 

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -445,6 +445,9 @@ public class Parser {
                                   :
                                          "        public native @Name(\"operator *\") " + valueType.annotations + valueType.javaName + " get();\n")
                                   +  "    }\n";
+                        if (infoMap.getFirst(containerType.cppName + "::" + iteratorType) == null) {
+                            infoMap.put(new Info(containerType.cppName + "::" + iteratorType).pointerTypes(containerType.javaName + ".Iterator"));
+                        }
                     }
                     if (resizable) {
                         valueType.javaName = removeAnnotations(valueType.javaName);


### PR DESCRIPTION
Records the mapping for container iterators.
Allows to map native functions (other that the container functions) taking or returning such iterators.
Presets can always register the info explicitly, in addition to the mapping for the container itself. This PR just makes that systematic.

Mapping is not recorded if an info already exists for the iterator. Maybe we should amend it if it exists instead.