### PR TITLE
Add front and back to list,vector, deque and array containers

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -428,6 +428,13 @@ public class Parser {
                         if (indexType != null && !indexType.annotations.contains("@Const") && !indexType.annotations.contains("@Cast") && !indexType.value) {
                             indexType.annotations += "@Const ";
                         }
+                        if (containerName.toLowerCase().endsWith("vector")
+                            || containerName.toLowerCase().endsWith("deque")
+                            || containerName.toLowerCase().endsWith("array")
+                            || containerName.toLowerCase().endsWith("list")) {
+                            decl.text += "    public native " + valueType.annotations + valueType.javaName + " front();\n"
+                                      +  "    public native " + valueType.annotations + valueType.javaName + " back();\n";
+                        }
                         if (!valueType.annotations.contains("@Const") && !valueType.value) {
                             valueType.annotations += "@Const ";
                         }


### PR DESCRIPTION
Add `front()` and `back()` to the containers that support them.
This is for convenience only, since `front()` should be equivalent to `begin().access()`, so feel free to reject it.