### PR TITLE
Add reset() to optional containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Let `Parser` output `reset()` methods for basic containers like `std::optional` ([pull #696](https://github.com/bytedeco/javacpp/pull/696))
  * Let `Parser` define `front()` and `back()` for one-dimensional basic containers ([pull #695](https://github.com/bytedeco/javacpp/pull/695))
  * Let `Parser` map iterators of basic containers systematically ([pull #694](https://github.com/bytedeco/javacpp/pull/694))
  * Fix `Parser` for function parameters contained in template arguments ([pull #693](https://github.com/bytedeco/javacpp/pull/693))

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -399,6 +399,7 @@ public class Parser {
                         for (Type type : containerType.arguments) {
                             if (containerType.arguments.length == 1 && !tuple) {
                                 decl.text += "    public native boolean has_value();\n"
+                                          +  "    public native void reset();\n"
                                           +  "    public native @Name(\"value\") " + type.annotations + type.javaName + " get();\n";
                             } else {
                                 int namespace = containerName.lastIndexOf("::");


### PR DESCRIPTION
What about adding `reset()` to `optional` container ?
The only alternative to clear the value of an optional I'm aware of, is to assign from a default-constructed optional:
```Java
  MyOptional optional;
  ...
  optional.put(new MyOptional())
```