### PR TITLE
Add of for downcasting when c-style cast cannot work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
  * Enhance `Parser` by adding downcast constructors for polymorphic classes ([pull #700](https://github.com/bytedeco/javacpp/pull/700))
+ * Let `Generator` pick up `@Name` annotations on `allocate()` as well ([pull #700](https://github.com/bytedeco/javacpp/pull/700))
  * Fix `Parser` failing to place annotations on default constructors ([pull #699](https://github.com/bytedeco/javacpp/pull/699))
  * Let `Parser` output `reset()` methods for basic containers like `std::optional` ([pull #696](https://github.com/bytedeco/javacpp/pull/696))
  * Let `Parser` define `front()` and `back()` for one-dimensional basic containers ([pull #695](https://github.com/bytedeco/javacpp/pull/695))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Enhance `Parser` by adding downcast constructors for polymorphic classes ([pull #700](https://github.com/bytedeco/javacpp/pull/700))
  * Fix `Parser` failing to place annotations on default constructors ([pull #699](https://github.com/bytedeco/javacpp/pull/699))
  * Let `Parser` output `reset()` methods for basic containers like `std::optional` ([pull #696](https://github.com/bytedeco/javacpp/pull/696))
  * Let `Parser` define `front()` and `back()` for one-dimensional basic containers ([pull #695](https://github.com/bytedeco/javacpp/pull/695))

--- a/src/main/java/org/bytedeco/javacpp/annotation/Adapter.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Adapter.java
@@ -10,22 +10,82 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.tools.Generator;
 
 /**
- * Specifies a C++ class to act as an adapter to convert the types of arguments.
- * Three such C++ classes made available by {@link Generator} are {@code StringAdapter},
- * {@code VectorAdapter}, and {@code SharedPtrAdapter} to bridge a few differences between
- * {@code std::string} and {@link String}; between {@code std::vector}, Java arrays of
- * primitive types, {@link Buffer}, and {@link Pointer}; and between {@code xyz::shared_ptr}
- * and {@link Pointer}. Adapter classes must define the following public members:
- * <ul>
- * <li> A constructor accepting 3 arguments (or more if {@link #argc()} > 1): a pointer, a size, and the owner pointer
- * <li> Another constructor that accepts a reference to the object of the other class
- * <li> A {@code static void deallocate(owner)} function
- * <li> Overloaded cast operators to both types, for references and pointers
- * <li> A {@code void assign(pointer, size, owner)} function
- * <li> A {@code size} member variable for arrays accessed via pointer
- * </ul>
- * To reduce further the amount of coding, this annotation can also be used on
- * other annotations, such as with {@link StdString}, {@link StdVector}, and {@link SharedPtr}.
+ * Specifies a C++ class to act as an adapter between a target type and one or more adaptee type(s).
+ * Instances of the adapter class are short-living and last only for the duration of a JNI call.
+ * <p></p>
+ * Six such C++ classes are made available by {@link Generator}:
+ * <blockquote>
+ * <table width="80%">
+ *     <thead>
+ *         <tr>
+ *             <th>Adapter class</th><th>Target type</th><th>Adaptee types</th><th>Helper annotation</th>
+ *         </tr>
+ *     </thead>
+ *     <tbody>
+ *         <tr>
+ *             <td valign="top">{@code VectorAdapter<P,T,A>}</td>
+ *             <td valign="top">{@code std::vector<T,A>}</td>
+ *             <td valign="top">{@code P}</td>
+ *             <td valign="top">{@link StdVector}</td>
+ *         </tr>
+ *         <tr>
+ *             <td valign="top">{@code StringAdapter<T>}</td>
+ *             <td valign="top">{@code std::basic_string<T>}</td>
+ *             <td valign="top">{@code char}<br>{@code signed char}<br>{@code unsigned char}<br>{@code wchar_t}<br>{@code unsigned short}<br>{@code signed int}</td>
+ *             <td valign="top">{@link StdString}</td>
+ *         </tr>
+ *         <tr>
+ *             <td valign="top">{@code SharedPtrAdapter<T>}</td>
+ *             <td valign="top">{@code SHARED_PTR_NAMESPACE::shared_ptr<T>}</td>
+ *             <td valign="top">{@code T}</td>
+ *             <td valign="top">{@link SharedPtr}</td>
+ *         </tr>
+ *         <tr>
+ *             <td valign="top">{@code UniquePtrAdapter<T,D>}</td>
+ *             <td valign="top">{@code UNIQUE_PTR_NAMESPACE::unique_ptr<T,D>}</td>
+ *             <td valign="top">{@code T}</td>
+ *             <td valign="top">{@link UniquePtr}</td>
+ *         </tr>
+ *         <tr>
+ *             <td valign="top">{@code MoveAdapter<T,D>}</td>
+ *             <td valign="top">{@code T}</td>
+ *             <td valign="top">{@code T}</td>
+ *             <td valign="top">{@link StdMove}</td>
+ *         </tr>
+ *         <tr>
+ *             <td valign="top">{@code OptionalAdapter<T>}</td>
+ *             <td valign="top">{@code OPTIONAL_NAMESPACE::optional<T>}</td>
+ *             <td valign="top">{@code T}</td>
+ *             <td valign="top">{@link Optional}</td>
+ *         </tr>
+ *     </tbody>
+ * </table>
+ * </blockquote>
+ * The helper annotations are shortcuts that infer the template type(s) of the adapter class from the Java
+ * class they annotate.
+ * <p></p>
+ * When an argument of a method is annotated, an instance of the adapter class is created from
+ * the Java object passed as argument, and this instance is passed to the C++ function, thus triggering
+ * an implicit cast to the type expected by the function (usually a reference or pointer to the target type).
+ * If the argument is also annotated with {@link Cast},
+ * the adapter instance is cast to the type(s) specified by the {@link Cast} annotation before being passed
+ * to the function.
+ * <p></p>
+ * When a method is annotated, an instance of the adapter is created from the
+ * value (usually a pointer or reference to the target type) returned by the C++ function or by {@code new} if the method is an allocator.
+ * If the method is also annotated with {@link Cast}, the value returned by the C++ function is
+ * cast by value 3 of the {@link Cast} annotation, if any, before instantiation of the adapter.
+ * Then a Java object is created from the adapter to be returned by the method.
+ * <p></p>
+ * Adapter classes must at least define the following public members:
+ *  <ul>
+ *  <li> For each adaptee type, a constructor accepting 3 arguments (or more if {@link #argc()} > 1): a pointer to a const value of the adaptee, a size, and the owner pointer
+ *  <li> Another constructor that accepts a reference to the target type
+ *  <li> A {@code static void deallocate(owner)} function
+ *  <li> Overloaded cast operators to both the target type and the adaptee types, for references and pointers
+ *  <li> {@code void assign(pointer, size, owner)} functions with the same signature than the constructors accepting 3 arguments
+ *  <li> A {@code size} member variable for arrays accessed via pointer
+ *  </ul>
  *
  * @see Generator
  *

--- a/src/main/java/org/bytedeco/javacpp/annotation/Adapter.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Adapter.java
@@ -14,8 +14,8 @@ import org.bytedeco.javacpp.tools.Generator;
  * Instances of the adapter class are short-living and last only for the duration of a JNI call.
  * <p></p>
  * Six such C++ classes are made available by {@link Generator} to bridge a few differences, for instance,
- * between {@code std::string} and {@link String}, between {@code std::vector}, Java arrays of
- *  primitive types, {@link Buffer}, and {@link Pointer}, or between {@code xyz::shared_ptr} and {@link Pointer}:
+ * between {@code std::string} and {@link String}, between {@code std::vector}, Java arrays of primitive
+ * types, {@link Buffer}, and {@link Pointer}, or between {@code xyz::shared_ptr} and {@link Pointer}:
  * <blockquote>
  * <table width="80%">
  *     <thead>
@@ -69,12 +69,11 @@ import org.bytedeco.javacpp.tools.Generator;
  * When an argument of a method is annotated, an instance of the adapter class is created from
  * the Java object passed as argument, and this instance is passed to the C++ function, thus triggering
  * an implicit cast to the type expected by the function (usually a reference or pointer to the target type).
- * If the argument is also annotated with {@link Cast},
- * the adapter instance is cast to the type(s) specified by the {@link Cast} annotation before being passed
- * to the function.
+ * If the argument is also annotated with {@link Cast}, the adapter instance is cast to the type(s) specified
+ * by the {@link Cast} annotation before being passed to the function.
  * <p></p>
- * When a method is annotated, an instance of the adapter is created from the
- * value (usually a pointer or reference to the target type) returned by the C++ function or by {@code new} if the method is an allocator.
+ * When a method is annotated, an instance of the adapter is created from the value (usually a pointer or
+ * reference to the target type) returned by the C++ function or by {@code new} if the method is an allocator.
  * If the method is also annotated with {@link Cast}, the value returned by the C++ function is
  * cast by value 3 of the {@link Cast} annotation, if any, before instantiation of the adapter.
  * Then a Java object is created from the adapter to be returned by the method.
@@ -88,6 +87,8 @@ import org.bytedeco.javacpp.tools.Generator;
  *  <li> {@code void assign(pointer, size, owner)} functions with the same signature than the constructors accepting 3 arguments
  *  <li> A {@code size} member variable for arrays accessed via pointer
  *  </ul>
+ * To reduce further the amount of coding, this annotation can also be used on
+ * other annotations, such as with {@link StdString}, {@link StdVector}, and {@link SharedPtr}.
  *
  * @see Generator
  *

--- a/src/main/java/org/bytedeco/javacpp/annotation/Adapter.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Adapter.java
@@ -13,7 +13,9 @@ import org.bytedeco.javacpp.tools.Generator;
  * Specifies a C++ class to act as an adapter between a target type and one or more adaptee type(s).
  * Instances of the adapter class are short-living and last only for the duration of a JNI call.
  * <p></p>
- * Six such C++ classes are made available by {@link Generator}:
+ * Six such C++ classes are made available by {@link Generator} to bridge a few differences, for instance,
+ * between {@code std::string} and {@link String}, between {@code std::vector}, Java arrays of
+ *  primitive types, {@link Buffer}, and {@link Pointer}, or between {@code xyz::shared_ptr} and {@link Pointer}:
  * <blockquote>
  * <table width="80%">
  *     <thead>

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -2645,11 +2645,16 @@ public class Generator {
                     prefix = "";
                     suffix = "";
                 } else {
-                    out.print((noException(methodInfo.cls, methodInfo.method) ?
-                        "new (std::nothrow) " : "new ") + valueTypeName + typeName[1]);
-                    if (methodInfo.arrayAllocator) {
-                        prefix = "[";
-                        suffix = "]";
+                    if (methodInfo.method.isAnnotationPresent(Name.class)) {
+                        out.print(methodInfo.memberName[0]);
+                        // If method is an array allocator, the function must return a pointer to an array
+                    } else {
+                        out.print((noException(methodInfo.cls, methodInfo.method) ?
+                            "new (std::nothrow) " : "new ") + valueTypeName + typeName[1]);
+                        if (methodInfo.arrayAllocator) {
+                            prefix = "[";
+                            suffix = "]";
+                        }
                     }
                 }
             } else if (Modifier.isStatic(methodInfo.modifiers) || !Pointer.class.isAssignableFrom(methodInfo.cls)) {
@@ -2814,12 +2819,8 @@ public class Generator {
             // special considerations for std::string without adapter
             out.print(");\n" + indent + "rptr = rstr.c_str()");
         }
-        if (adapterInfo != null) {
-            if (methodInfo.allocator || methodInfo.arrayAllocator) {
-                suffix = ", 1, NULL)" + suffix;
-            } else if (!methodInfo.returnType.isPrimitive()) {
-                suffix = ")" + suffix;
-            }
+        if ((methodInfo.allocator || methodInfo.arrayAllocator || !methodInfo.returnType.isPrimitive()) && adapterInfo != null) {
+            suffix = ")" + suffix;
         }
         if ((Pointer.class.isAssignableFrom(methodInfo.returnType) ||
                 (methodInfo.returnType.isArray() &&

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -61,6 +61,7 @@ public class Info {
         skip = i.skip;
         skipDefaults = i.skipDefaults;
         purify = i.purify;
+        polymorphic = i.polymorphic;
         upcast = i.upcast;
         virtualize = i.virtualize;
         base = i.base;
@@ -120,6 +121,10 @@ public class Info {
     /** Whether a static_cast is needed to upcast a pointer to this cppName.
      * This is necessary for polymorphic classes that are virtually inherited from. */
     boolean upcast = false;
+    /** Inform the parser that a class is polymorphic, if it cannot figure it out by itself.
+     * Knowing that a class is polymorphic is needed to generate proper downcast
+     * methods in case of virtual and multiple inheritance. */
+    boolean polymorphic = false;
     /** Annotates virtual functions with @{@link Virtual} and adds appropriate constructors. */
     boolean virtualize = false;
     /** Allows to override the base class of {@link #pointerTypes}. Defaults to {@link Pointer}. */
@@ -162,6 +167,8 @@ public class Info {
     public Info purify(boolean purify) { this.purify = purify; return this; }
     public Info upcast() { this.upcast = true; return this; }
     public Info upcast(boolean upcast) { this.upcast = upcast; return this; }
+    public Info polymorphic() { this.polymorphic = true; return this; }
+    public Info polymorphic(boolean p) { this.polymorphic = p; return this; }
     public Info virtualize() { this.virtualize = true; return this; }
     public Info virtualize(boolean virtualize) { this.virtualize = virtualize; return this; }
     public Info base(String base) { this.base = base; return this; }

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -61,7 +61,6 @@ public class Info {
         skip = i.skip;
         skipDefaults = i.skipDefaults;
         purify = i.purify;
-        polymorphic = i.polymorphic;
         upcast = i.upcast;
         virtualize = i.virtualize;
         base = i.base;
@@ -121,10 +120,6 @@ public class Info {
     /** Whether a static_cast is needed to upcast a pointer to this cppName.
      * This is necessary for polymorphic classes that are virtually inherited from. */
     boolean upcast = false;
-    /** Inform the parser that a class is polymorphic, if it cannot figure it out by itself.
-     * Knowing that a class is polymorphic is needed to generate proper downcast
-     * methods in case of virtual and multiple inheritance. */
-    boolean polymorphic = false;
     /** Annotates virtual functions with @{@link Virtual} and adds appropriate constructors. */
     boolean virtualize = false;
     /** Allows to override the base class of {@link #pointerTypes}. Defaults to {@link Pointer}. */
@@ -167,8 +162,6 @@ public class Info {
     public Info purify(boolean purify) { this.purify = purify; return this; }
     public Info upcast() { this.upcast = true; return this; }
     public Info upcast(boolean upcast) { this.upcast = upcast; return this; }
-    public Info polymorphic() { this.polymorphic = true; return this; }
-    public Info polymorphic(boolean p) { this.polymorphic = p; return this; }
     public Info virtualize() { this.virtualize = true; return this; }
     public Info virtualize(boolean virtualize) { this.virtualize = virtualize; return this; }
     public Info base(String base) { this.base = base; return this; }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3845,14 +3845,14 @@ public class Parser {
 
             if (implicitConstructor && (info == null || !info.purify) && (!abstractClass || ctx.virtualize)) {
                 constructors += "    /** Default native constructor. */\n" +
-                                "    public " + shortName + "() { super((Pointer)null); allocate(); }\n";
+                             "    public " + shortName + "() { super((Pointer)null); allocate(); }\n";
                 if (constructorAnnotations.isEmpty()) {
                     constructors += "    /** Native array allocator. Access with {@link Pointer#position(long)}. */\n" +
-                                    "    public " + shortName + "(long size) { super((Pointer)null); allocateArray(size); }\n";
+                                 "    public " + shortName + "(long size) { super((Pointer)null); allocateArray(size); }\n";
                 }
                 constructors += "    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */\n" +
-                                "    public " + shortName + "(Pointer p) { super(p); }\n" +
-                                "    " + constructorAnnotations + "private native void allocate();\n";
+                             "    public " + shortName + "(Pointer p) { super(p); }\n" +
+                             "    " + constructorAnnotations + "private native void allocate();\n";
                 if (constructorAnnotations.isEmpty()) {
                     /* Annotations currently used on constructors are @SharedPtr and @Name. @SharedPtr produces
                      * memory corruption if applied to arrays. And @Name needs special versions of the provided
@@ -3861,12 +3861,12 @@ public class Parser {
                      * position and getPointer are incompatible with @SharedPtr, but compatible with @Name.
                      * Since we don't distinguish annotations here, we disable them in both cases. */
                     constructors += "    private native void allocateArray(long size);\n" +
-                                    "    @Override public " + shortName + " position(long position) {\n" +
-                                    "        return (" + shortName + ")super.position(position);\n" +
-                                    "    }\n" +
-                                    "    @Override public " + shortName + " getPointer(long i) {\n" +
-                                    "        return new " + shortName + "((Pointer)this).offsetAddress(i);\n" +
-                                    "    }\n";
+                                 "    @Override public " + shortName + " position(long position) {\n" +
+                                 "        return (" + shortName + ")super.position(position);\n" +
+                                 "    }\n" +
+                                 "    @Override public " + shortName + " getPointer(long i) {\n" +
+                                 "        return new " + shortName + "((Pointer)this).offsetAddress(i);\n" +
+                                 "    }\n";
                 }
             } else {
                 if ((info == null || !info.purify) && (!abstractClass || ctx.virtualize)) {
@@ -3875,22 +3875,21 @@ public class Parser {
 
                 if (!pointerConstructor) {
                     constructors += "    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */\n" +
-                                    "    public " + shortName + "(Pointer p) { super(p); }\n";
+                                 "    public " + shortName + "(Pointer p) { super(p); }\n";
                 }
                 if (defaultConstructor && (info == null || !info.purify) && (!abstractClass || ctx.virtualize) && !arrayConstructor
                     && constructorAnnotations.isEmpty() /* See comment above */) {
                     constructors += "    /** Native array allocator. Access with {@link Pointer#position(long)}. */\n" +
-                                    "    public " + shortName + "(long size) { super((Pointer)null); allocateArray(size); }\n" +
-                                    "    private native void allocateArray(long size);\n" +
-                                    "    @Override public " + shortName + " position(long position) {\n" +
-                                    "        return (" + shortName + ")super.position(position);\n" +
-                                    "    }\n" +
-                                    "    @Override public " + shortName + " getPointer(long i) {\n" +
-                                    "        return new " + shortName + "((Pointer)this).offsetAddress(i);\n" +
-                                    "    }\n";
+                                 "    public " + shortName + "(long size) { super((Pointer)null); allocateArray(size); }\n" +
+                                 "    private native void allocateArray(long size);\n" +
+                                 "    @Override public " + shortName + " position(long position) {\n" +
+                                 "        return (" + shortName + ")super.position(position);\n" +
+                                 "    }\n" +
+                                 "    @Override public " + shortName + " getPointer(long i) {\n" +
+                                 "        return new " + shortName + "((Pointer)this).offsetAddress(i);\n" +
+                                 "    }\n";
                 }
             }
-
             if (info == null || !info.skipDefaults) {
                 decl.text += constructors;
             }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3406,9 +3406,9 @@ public class Parser {
         res += "    /** Downcast constructor. */\n" +
                "    public " + derived.javaName + "(" + base.javaName + " pointer) { super((Pointer)null); allocate(pointer); }\n";
         if (annotations.isEmpty()) {
-            res += "    @Namespace private native @Name(\"" + downcastType + "_cast<" + derived.cppName + "*>\") void allocate(" + base.javaName + " pointer);";
+            res += "    @Namespace private native @Name(\"" + downcastType + "_cast<" + derived.cppName + "*>\") void allocate(" + base.javaName + " pointer);\n";
         } else {
-            res += "    @Namespace private native " + annotations + "@Name(\"SHARED_PTR_NAMESPACE::" + downcastType + "_pointer_cast<" + derived.cppName + ", " + base.cppName + ">\") void allocate(" + annotations + base.javaName + " pointer);";
+            res += "    @Namespace private native " + annotations + "@Name(\"SHARED_PTR_NAMESPACE::" + downcastType + "_pointer_cast<" + derived.cppName + ", " + base.cppName + ">\") void allocate(" + annotations + base.javaName + " pointer);\n";
         }
         return res;
     }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -97,9 +97,19 @@ public class Parser {
     InfoMap leafInfoMap = null;
     TokenIndexer tokens = null;
     String lineSeparator = null;
-    Set<String> upcasts = new HashSet<>(); // Java names of base classes needing upcast
-    Map<String, Set<Type>> downcasts = new HashMap<>(); // Keys: classes which child classes needs downcast constructor. Values: classes to downcast from.
-    HashSet<String> polymorphicClasses = new HashSet<>(); // Contains Java names
+    /**
+     * Java names of classes needing upcast from their subclasses.
+     */
+    Set<String> upcasts = new HashSet<>();
+    /**
+     * Classes that have a base class appearing as key in this map need a downcast constructor.
+     * The associated value gives the class to downcast from.
+     */
+    Map<String, Set<Type>> downcasts = new HashMap<>();
+    /**
+     * Java names of classes recognized as polymorphic.
+     */
+    Set<String> polymorphicClasses = new HashSet<>();
 
     private void addDowncast(String base, Type from) {
         Set<Type> types = downcasts.get(base);

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3843,45 +3843,53 @@ public class Parser {
                 }
             }
 
-            final boolean addArrayConstructor, addDefaultConstructor, addPointerCastConstructor;
-            /* Annotations currently used on constructors are @SharedPtr and @Name. @SharedPtr produces
-             * memory corruption if applied to arrays. And @Name needs special versions of the provided
-             * C++ function that return arrays. So for safety we disable arrays for classes with
-             * annotations on constructor.
-             * position and getPointer are incompatible with @SharedPtr, but compatible with @Name.
-             * Since we don't distinguish annotations here, we disable them in both cases. */
             if (implicitConstructor && (info == null || !info.purify) && (!abstractClass || ctx.virtualize)) {
-                addDefaultConstructor = addPointerCastConstructor = true;
-                addArrayConstructor = constructorAnnotations.isEmpty();
+                constructors += "    /** Default native constructor. */\n" +
+                                "    public " + shortName + "() { super((Pointer)null); allocate(); }\n";
+                if (constructorAnnotations.isEmpty()) {
+                    constructors += "    /** Native array allocator. Access with {@link Pointer#position(long)}. */\n" +
+                                    "    public " + shortName + "(long size) { super((Pointer)null); allocateArray(size); }\n";
+                }
+                constructors += "    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */\n" +
+                                "    public " + shortName + "(Pointer p) { super(p); }\n" +
+                                "    " + constructorAnnotations + "private native void allocate();\n";
+                if (constructorAnnotations.isEmpty()) {
+                    /* Annotations currently used on constructors are @SharedPtr and @Name. @SharedPtr produces
+                     * memory corruption if applied to arrays. And @Name needs special versions of the provided
+                     * C++ function that return arrays. So for safety we disable arrays for classes with
+                     * annotations on constructor.
+                     * position and getPointer are incompatible with @SharedPtr, but compatible with @Name.
+                     * Since we don't distinguish annotations here, we disable them in both cases. */
+                    constructors += "    private native void allocateArray(long size);\n" +
+                                    "    @Override public " + shortName + " position(long position) {\n" +
+                                    "        return (" + shortName + ")super.position(position);\n" +
+                                    "    }\n" +
+                                    "    @Override public " + shortName + " getPointer(long i) {\n" +
+                                    "        return new " + shortName + "((Pointer)this).offsetAddress(i);\n" +
+                                    "    }\n";
+                }
             } else {
                 if ((info == null || !info.purify) && (!abstractClass || ctx.virtualize)) {
                     constructors += inheritedConstructors;
                 }
-                addDefaultConstructor = false;
-                addPointerCastConstructor = !pointerConstructor;
-                addArrayConstructor =  (defaultConstructor && (info == null || !info.purify) && (!abstractClass || ctx.virtualize)
-                    && !arrayConstructor && constructorAnnotations.isEmpty());
-            }
 
-            if (addDefaultConstructor)
-              constructors += "    /** Default native constructor. */\n" +
-                              "    public " + shortName + "() { super((Pointer)null); allocate(); }\n";
-            if (addArrayConstructor)
-              constructors +=  "    /** Native array allocator. Access with {@link Pointer#position(long)}. */\n" +
-                               "    public " + shortName + "(long size) { super((Pointer)null); allocateArray(size); }\n";
-            if (addPointerCastConstructor)
-              constructors +=  "    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */\n" +
-                               "    public " + shortName + "(Pointer p) { super(p); }\n";
-            if (addDefaultConstructor)
-              constructors +=  "    " + constructorAnnotations + "private native void allocate();\n";
-            if (addArrayConstructor)
-              constructors +=  "    private native void allocateArray(long size);\n" +
-                               "    @Override public " + shortName + " position(long position) {\n" +
-                               "        return (" + shortName + ")super.position(position);\n" +
-                               "    }\n" +
-                               "    @Override public " + shortName + " getPointer(long i) {\n" +
-                               "        return new " + shortName + "((Pointer)this).offsetAddress(i);\n" +
-                               "    }\n";
+                if (!pointerConstructor) {
+                    constructors += "    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */\n" +
+                                    "    public " + shortName + "(Pointer p) { super(p); }\n";
+                }
+                if (defaultConstructor && (info == null || !info.purify) && (!abstractClass || ctx.virtualize) && !arrayConstructor
+                    && constructorAnnotations.isEmpty() /* See comment above */) {
+                    constructors += "    /** Native array allocator. Access with {@link Pointer#position(long)}. */\n" +
+                                    "    public " + shortName + "(long size) { super((Pointer)null); allocateArray(size); }\n" +
+                                    "    private native void allocateArray(long size);\n" +
+                                    "    @Override public " + shortName + " position(long position) {\n" +
+                                    "        return (" + shortName + ")super.position(position);\n" +
+                                    "    }\n" +
+                                    "    @Override public " + shortName + " getPointer(long i) {\n" +
+                                    "        return new " + shortName + "((Pointer)this).offsetAddress(i);\n" +
+                                    "    }\n";
+                }
+            }
 
             if (info == null || !info.skipDefaults) {
                 decl.text += constructors;

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3661,12 +3661,6 @@ public class Parser {
             addDowncast(base.cppName, base);
         }
 
-        Set<Type> froms = downcasts.get(base.cppName);
-        if (froms != null)
-            for (Type t: froms) {
-                casts += downcast(type, t);
-            }
-
         decl.signature = type.javaName;
         tokens.index = startIndex;
         String shortName = name.substring(name.lastIndexOf('.') + 1);
@@ -3889,6 +3883,17 @@ public class Parser {
                                  "    }\n";
                 }
             }
+
+            Set<Type> froms = downcasts.get(base.cppName);
+            if (froms != null)
+                ADD_DOWNCAST:
+                for (Type t: froms) {
+                    for (Declaration d : declList2)
+                        if ((shortName + "_" + t.javaName).equals(d.signature))
+                            break ADD_DOWNCAST;
+                    constructors += downcast(type, t);
+                }
+
             if (info == null || !info.skipDefaults) {
                 decl.text += constructors;
             }

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -97,18 +97,11 @@ public class Parser {
     InfoMap leafInfoMap = null;
     TokenIndexer tokens = null;
     String lineSeparator = null;
-    /**
-     * Java names of classes needing upcast from their subclasses.
-     */
+    /** Java names of classes needing upcast from their subclasses. */
     Set<String> upcasts = new HashSet<>();
-    /**
-     * Classes that have a base class appearing as key in this map need a downcast constructor.
-     * The associated value gives the class to downcast from.
-     */
+    /** Classes that have a base class appearing as key in this map need a downcast constructor. The associated value gives the class to downcast from. */
     Map<String, Set<Type>> downcasts = new HashMap<>();
-    /**
-     * Java names of classes recognized as polymorphic.
-     */
+    /** Java names of classes recognized as polymorphic. */
     Set<String> polymorphicClasses = new HashSet<>();
 
     private void addDowncast(String base, Type from) {

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -277,10 +276,10 @@ public class Parser {
                     dcl.definition.text = "\n" + dcl.definition.text;
                     decl.declarator = dcl;
                 }
-                LinkedList<Type> typeSet = new LinkedList<>();
-                typeSet.addAll(Arrays.asList(firstType, secondType, indexType, valueType));
-                typeSet.addAll(Arrays.asList(containerType.arguments));
-                for (Type type : typeSet) {
+                ArrayList<Type> types = new ArrayList<>(4 + containerType.arguments.length);
+                types.addAll(Arrays.asList(firstType, secondType, indexType, valueType));
+                types.addAll(Arrays.asList(containerType.arguments));
+                for (Type type : types) {
                     if (type == null) {
                         continue;
                     } else if (type.annotations == null || type.annotations.length() == 0) {

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3567,17 +3567,17 @@ public class Parser {
             infoMap.put(info = new Info(type.cppName).pointerTypes(type.javaName));
         }
         Type base = new Type("Pointer");
-        boolean polymorphic = info != null && info.polymorphic;
+        /* The detection of polymorphism can fail if the base class has not been parsed yet, or is not
+         * parsed at all. We might need to add a "polymorphic" info flag and initialize this variable
+         * to true when info.polymorphic is set, and check nextInfo.polymorphic in the loop. */
+        boolean polymorphic = false;
         Iterator<Type> it = baseClasses.iterator();
         while (it.hasNext()) {
             Type next = it.next();
             Info nextInfo = infoMap.getFirst(next.cppName);
-            boolean nextPolymorphic = polymorphicClasses.contains(next.javaName) ||
-                (nextInfo != null && nextInfo.polymorphic);
+            boolean nextPolymorphic = polymorphicClasses.contains(next.javaName);
             polymorphic |= nextPolymorphic;
             if (nextPolymorphic && next.virtual && !upcasts.contains(next.javaName)) {
-                // We can detect this only if the superclass is parsed before or
-                // info.polymorphic is set.
                 logger.warn(type.cppName + " virtually inherits from polymorphic class " + next.cppName +
                     ". Consider adding an upcast Info on " + next.cppName + ".");
             }

--- a/src/main/java/org/bytedeco/javacpp/tools/Type.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Type.java
@@ -51,6 +51,10 @@ class Type {
         }
     }
 
+    @Override public int hashCode() {
+        return cppName.hashCode() ^ javaName.hashCode();
+    }
+
     String signature() {
         String sig = "";
         for (char c : javaName.substring(javaName.lastIndexOf(' ') + 1).toCharArray()) {

--- a/src/test/java/org/bytedeco/javacpp/AdapterTest.java
+++ b/src/test/java/org/bytedeco/javacpp/AdapterTest.java
@@ -27,6 +27,7 @@ import org.bytedeco.javacpp.annotation.ByRef;
 import org.bytedeco.javacpp.annotation.Cast;
 import org.bytedeco.javacpp.annotation.Const;
 import org.bytedeco.javacpp.annotation.Function;
+import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Optional;
 import org.bytedeco.javacpp.annotation.Platform;
 import org.bytedeco.javacpp.annotation.SharedPtr;
@@ -82,7 +83,7 @@ public class AdapterTest {
     static class SharedData extends Pointer {
         SharedData(Pointer p) { super(p); }
         SharedData(int data) { allocate(data); }
-        @SharedPtr native void allocate(int data);
+        @SharedPtr @Name("std::make_shared<SharedData>") native void allocate(int data);
 
         native int data(); native SharedData data(int data);
     }


### PR DESCRIPTION
The `asB()` method generated by the Parser allows to upcast an instance of a class `D` to an instance of one of its base class `B` in the cases where C-style pointer cast (as used for instance in pointer cast constructors `B(Pointer)` does not work.

This is useful for multiple inheritance and for virtual inheritance from a polymorphic class.

But we lack the equivalent downcast.
```
struct B1 {
  int i;
};
struct B2 {
  int j;
};
struct D: public B1, public B2 {
  int k;
}
```
In Java, `D` extends `B1` and has a `asB2()` method.
But if we have an instance `b2` of `B2` that we know is a `D`, we have no way to cast it to an instance of `D`. `new D(b2)` will lead to a segmentation fault.

For polymorphic classes, here is an example from Pytorch: `LinearImpl` extends `Module` (through `LinearImplCloneable`). Say we get a instance of `Module` from one of the many functions of libtorch returning a Module, we know it's a `LinearImpl`, and we need to call its `forward` function. We cannot. `new LinearImpl(module).forward(tensor)` triggers a segmentation fault (see issue https://github.com/bytedeco/javacpp-presets/issues/1393).

This PR adds a static `of(B)` method, along with the `asB()` method, to perform the downcast. This static method does a `static_cast`/`static_pointer_cast` or a `dynamic_cast`/`dynamic_pointer_cast`. The C++ rules that determine which casting flavor to use are as follows:
* When downcasting through virtual inheritance, static cast cannot be used.
* Dynamic cast can only be used if the source class is polymorphic (having at least 1 virtual member, declared or inherited).

These rules imply that downcasting is not possible (without hacks we won't address) if inheritance is virtual but the base class is not polymorphic.

Virtual inheritance can be reliably detected by the parser.
Polymorphism can be detected too, but not reliably since a class can inherit virtual members from a class defined in a non-parsed, or non-parsed-yet,  header.
This PR also adds these detections to determine if downcast can be performed and which flavor to use. It also adds a `polymorphic` info to label a class as polymorphic when the Parser cannot detect it.
Not that `upcast` info is still needed because we most certainly need this information before we parse the subclass that declares a virtual inheritance and we realize `upcast` is needed. However I added a warning when we parse the subclass if the situation is detected and the `upcast` info has not been set.

Changes in existing presets: addition of `of` in presets with classes having multiple or virtual inheritance (hdf5, opencv, pytorch and tvm)

COULD BE IMPROVED:
It would be better if `of` were replaced by a constructor, acting as a specialization of the pointer cast constructor taking a `Pointer`. This way we limit the risk that the user triggers a segmentation fault by calling the pointer cast constructor when C-style cast won't work. But I don't see how to implement this easily as a constructor, without patching the generator. We could add something like:
```
public D(B pointer) { super(of(B)); }
```
and make `of` private, but it's not really satisfactory since it just duplicates the object returned by `of`. Any idea ?
