### PR TITLE
Updated Generator.java to fix the flaky errors

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -40,6 +40,7 @@ import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -2083,6 +2083,12 @@ public class Generator {
         }
 
         Method[] methods = cls.getDeclaredMethods();
+        Arrays.sort(methods, new Comparator<Method>() {
+            @Override
+            public int compare(Method m1, Method m2) {
+                return m1.getName().compareTo(m2.getName());
+            }
+        });
         MethodInformation[] methodInfos = new MethodInformation[methods.length];
         for (int i = 0; i < methods.length; i++) {
             methodInfos[i] = methodInformation(methods[i]);
@@ -3635,6 +3641,12 @@ public class Generator {
             return null;
         }
         Method[] methods = cls.getDeclaredMethods();
+        Arrays.sort(methods, new Comparator<Method>() {
+            @Override
+            public int compare(Method m1, Method m2) {
+                return m1.getName().compareTo(m2.getName());
+            }
+        });
         Method[] functionMethods = new Method[3];
         for (int i = 0; i < methods.length; i++) {
             String methodName = methods[i].getName();


### PR DESCRIPTION
**PR Overview:**
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering of methods returned by `getDeclaredMethods()`

[org.bytedeco.javacpp.BufferTest](https://github.com/bytedeco/javacpp/blob/master/src/test/java/org/bytedeco/javacpp/BufferTest.java)

[org.bytedeco.javacpp.EnumTest](https://github.com/bytedeco/javacpp/blob/master/src/test/java/org/bytedeco/javacpp/EnumTest.java)

[org.bytedeco.javacpp.PointerTest](https://github.com/bytedeco/javacpp/blob/master/src/test/java/org/bytedeco/javacpp/PointerTest.java)

**Test Overview:**
_________________________________________________________________________________________________________
In all of the above tests, the tests call the `setUpClass()` method where the problem arises. The `setUpClass()` makes an internal to the `Generator` class’s object where the problem resides.

You can reproduce the issue by running the following commands (the below command is for BufferTest, please change class name for targeting other tests) -

```
mvn install -pl . -am -DskipTests
mvn test  -Dtest=org.bytedeco.javacpp.BufferTest
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.bytedeco.javacpp.BufferTest
```


**Root Cause**
_________________________________________________________________________________________________________

`Method[] methods = cls.getDeclaredMethods();`


In the [`Generator`](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java) class, the `cls.getDeclaredMethods()` method returns an array with values in a non-deterministic order, leading to the core of the issue. Within the [`functionMethods()`](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L3639) method of the [`Generator`](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java)  class, there's a call to [`cls.getDeclaredMethods()` ](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L3643)used to populate the [`callbackAllocators[]`](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L3664) array. Additionally, the same [`cls.getDeclaredMethods()`](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L2085) method is invoked in the [`methods()`](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L2060) method of the [`Generator`](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java) class, which utilizes the [`callbackAllocators`](https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L2132) array. However, due to the differing order of results produced by `cls.getDeclaredMethods()`, it results in a test failure.
This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC

**Fix:**
_________________________________________________________________________________________________________
To fix the issue I decided to make the output of `callbackAllocators` array deterministic by ordering the `cls.getDeclaredMethods()` result both in  `methods()` method and `functionMethods()` method.
  
https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L2085-L2091

https://github.com/njain2208/javacpp/blob/4c62303548be1b9edc3e22d23d3674c397ff9829/src/main/java/org/bytedeco/javacpp/tools/Generator.java#L3643-L3649

