### PR TITLE
* Fix `InfoMap.normalize()` incorrectly rebuilding nested templates

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
@@ -247,6 +247,9 @@ public class InfoMap extends HashMap<String,List<Info>> {
             if (template >= 0) {
                 name = foundConst ? "const " : "";
                 for (int i = 0; i < template; i++) {
+                    if(tokens[i].match('>') && tokens[i-1].match('>')) {
+                        name += tokens[i].spacing;
+                    }
                     name += tokens[i];
                 }
                 for (int i = parameters; i < n; i++) {

--- a/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
@@ -247,8 +247,8 @@ public class InfoMap extends HashMap<String,List<Info>> {
             if (template >= 0) {
                 name = foundConst ? "const " : "";
                 for (int i = 0; i < template; i++) {
-                    if(tokens[i].match('>') && tokens[i-1].match('>')) {
-                        name += tokens[i].spacing;
+                    if(i > 0 && (tokens[i].match('>') && tokens[i-1].match('>') || tokens[i-1].match(Token.OPERATOR))) {
+                        name += " ";
                     }
                     name += tokens[i];
                 }


### PR DESCRIPTION
When `InfoMap.normalize()` is called on `"TemplatedClass<std::complex<double> >::funTemp<int>(const U&)"`, `name` is rebuilt as `"TemplatedClass<std::complex<double>>::funTemp<int>(const U&)"`, making the parser fail to correctly handle templated functions which are members of templated classes.
This ensures that spacing is maintained between `'>'` characters when they close templates.