### PR TITLE
Upgraded versions for various plugins.

### DIFF
--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -192,7 +192,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>properties</id>
@@ -214,7 +214,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.6.0</version>
         <configuration>
           <attach>false</attach>
           <descriptors>
@@ -233,7 +233,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>default-jar</id>
@@ -268,7 +268,7 @@
       <plugin>
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
-        <version>1.0.0.RC2</version>
+        <version>1.1.0</version>
         <configuration>
           <jvmVersion>9</jvmVersion>
           <overwriteExistingFiles>true</overwriteExistingFiles>
@@ -318,7 +318,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>sonatype-nexus-staging</serverId>
@@ -375,7 +375,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
-    <maven.version>3.0</maven.version>
-    <bnd.version>5.3.0</bnd.version>
+    <maven.version>3.9.0</maven.version>
+    <bnd.version>6.4.0</bnd.version>
     <javacpp.platform.root></javacpp.platform.root>
     <javacpp.platform.suffix></javacpp.platform.suffix>
     <javacpp.platform.compiler></javacpp.platform.compiler>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.36</version>
+      <version>2.0.9</version>
       <optional>true</optional>
     </dependency>
     <!--
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.annotation</artifactId>
-      <version>7.0.0</version>
+      <version>8.1.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -128,7 +128,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.2</version>
+        <version>3.9.0</version>
         <configuration>
           <packagingTypes>
             <packagingType>jar</packagingType>
@@ -146,7 +146,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.12.1</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
@@ -154,7 +154,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.3</version>
         <configuration>
           <systemProperties>
             <property>
@@ -187,7 +187,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <!-- Pull in the bnd generated manifest -->
@@ -218,7 +218,7 @@
       <plugin>
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
-        <version>1.0.0.RC2</version>
+        <version>1.1.0</version>
         <configuration>
           <jvmVersion>9</jvmVersion>
           <overwriteExistingFiles>true</overwriteExistingFiles>
@@ -244,14 +244,14 @@
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <createChecksum>true</createChecksum>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.6.0</version>
         <configuration>
           <attach>false</attach>
           <descriptors>
@@ -270,7 +270,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-source</id>
@@ -282,7 +282,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -312,7 +312,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>sonatype-nexus-staging</serverId>
@@ -406,7 +406,7 @@ Import-Package: \
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -438,7 +438,7 @@ Import-Package: \
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.1</version>
             <executions>
               <execution>
                 <phase>process-classes</phase>
@@ -553,7 +553,7 @@ Import-Package: \
           </plugin>
           <plugin>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>3.6.0</version>
               <configuration>
                 <cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
                 <cloneClean>true</cloneClean>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.9</version>
+      <version>1.7.36</version>
       <optional>true</optional>
     </dependency>
     <!--
@@ -154,7 +154,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.5</version>
         <configuration>
           <systemProperties>
             <property>

--- a/src/it/osgi/pom.xml
+++ b/src/it/osgi/pom.xml
@@ -9,7 +9,7 @@
   <description>Integration Tests for JavaCPP running in OSGi</description>
   
   <properties>
-    <bnd.version>5.3.0</bnd.version>
+    <bnd.version>6.4.0</bnd.version>
     <lib.path>${os.name}-${os.arch}/${lib.name}</lib.path>
   </properties>
   
@@ -158,13 +158,13 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>6.0.5</version>
+      <version>7.0.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.32</version>
+      <version>1.7.36</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/src/it/osgi/test.bndrun
+++ b/src/it/osgi/test.bndrun
@@ -1,10 +1,10 @@
 -runrequires: bnd.identity;id='javacpp-tests-osgi'
--runfw: org.apache.felix.framework;version='[6.0.5,6.0.5]'
+-runfw: org.apache.felix.framework;version='[7.0.5,7.0.5]'
 -runee: JavaSE-1.8
 -runbundles: \
 	org.bytedeco.javacpp;version='0.0.0',\
 	org.bytedeco.javacpp.${os.name}-${os.arch};version='0.0.0',\
 	javacpp-tests-osgi;version='0.0.0',\
 	org.apache.servicemix.bundles.junit;version='[4.13.2,4.13.3)',\
-	slf4j.api;version='[1.7.32,1.7.33)',\
-	slf4j.simple;version='[1.7.32,1.7.33)'
+	slf4j.api;version='[1.7.36,1.7.37)',\
+	slf4j.simple;version='[1.7.36,1.7.37)'


### PR DESCRIPTION
I upgraded few plugins and mostly:
```
 <artifactId>maven-compiler-plugin</artifactId>
149         <version>3.12.1</version>
150         <configuration>
151           <source>1.8</source>
152           <target>1.8</target>
```
as it was failing on my system to build with 1.7 values:
```
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.3 LTS"
java 21.0.1 2023-10-17
Java(TM) SE Runtime Environment Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19)
Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19, mixed mode, sharing)

```
