### PR TITLE
Improve parsing of operator and function templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Improve `Parser` capabilities for `operator` and function templates ([pull #732](https://github.com/bytedeco/javacpp/pull/732))
  * Fix `Parser` failing on nested initializer lists and on attributes found inside `enum` declarations
  * Fix `Parser` for basic containers like `std::optional<std::pair<int,int> >` ([issue #718](https://github.com/bytedeco/javacpp/issues/718))
  * Add support for `std::basic_string` basic container ([issue bytedeco/javacpp-presets#1311](https://github.com/bytedeco/javacpp-presets/issues/1311))

--- a/src/main/java/org/bytedeco/javacpp/tools/DeclarationList.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/DeclarationList.java
@@ -70,7 +70,7 @@ class DeclarationList extends ArrayList<Declaration> {
             if (infoIterator == null) {
                 Type type = templateMap.type = decl.type;
                 Declarator dcl = templateMap.declarator = decl.declarator;
-                for (String name : new String[] {fullName, dcl != null ? dcl.cppName : type.cppName}) {
+                for (String name : new String[] {fullName, dcl != null ? (dcl.type.constructor ? Parser.constructorName(dcl.cppName) : dcl.cppName) : type.cppName}) {
                     if (name == null) {
                         continue;
                     }

--- a/src/main/java/org/bytedeco/javacpp/tools/DeclarationList.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/DeclarationList.java
@@ -66,7 +66,7 @@ class DeclarationList extends ArrayList<Declaration> {
         boolean add = true;
         if (templateMap != null && templateMap.empty() && !decl.custom && (decl.type != null || decl.declarator != null)) {
             // method templates cannot be declared in Java, but make sure to make their
-            // info available on request (when Info.javaNames is set) to be able to create instances
+            // info available on request (when Info.javaNames or Info.define is set) to be able to create instances
             if (infoIterator == null) {
                 Type type = templateMap.type = decl.type;
                 Declarator dcl = templateMap.declarator = decl.declarator;
@@ -75,12 +75,12 @@ class DeclarationList extends ArrayList<Declaration> {
                         continue;
                     }
                     List<Info> infoList = infoMap.get(name);
-                    boolean hasJavaName = false;
+                    boolean hasJavaNameOrDefine = false;
                     for (Info info : infoList) {
-                        hasJavaName |= info.javaNames != null && info.javaNames.length > 0;
+                        hasJavaNameOrDefine |= info.javaNames != null && info.javaNames.length > 0 || info.define;
                     }
-                    if (!decl.function || hasJavaName) {
-                        infoIterator = infoList.size() > 0 ? infoList.listIterator() : null;
+                    if (!decl.function || hasJavaNameOrDefine) {
+                        infoIterator = infoList.size() > 0 ? new ArrayList<>(infoList).listIterator() : null;
                         break;
                     }
                 }

--- a/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
@@ -47,7 +47,6 @@ public class InfoMap extends HashMap<String,List<Info>> {
                                                    "std::function", "std::basic_string"))
         .put(new Info("basic/types").cppTypes("signed", "unsigned", "char", "short", "int", "long", "bool", "float", "double",
                                               "__int8", "__int16", "__int32", "__int64", "_Bool", "_Complex", "_Imaginary", "complex", "imaginary"))
-        .put(new Info("deprecated").annotations("@Deprecated"))
         .put(new Info("noexcept").annotations("@NoException(true)"))
 
         .put(new Info("__COUNTER__").cppText("#define __COUNTER__ 0"))
@@ -192,10 +191,13 @@ public class InfoMap extends HashMap<String,List<Info>> {
             String lastComp = comps.get(paramsIdx - 1);
             comps.set(paramsIdx - 1, Templates.strip(lastComp));
             name = comps.get(0);
-            for (int i = 1; i < paramsIdx; i++)
+            for (int i = 1; i < paramsIdx; i++) {
                 name += "::" + comps.get(i);
+            }
             name += comps.get(paramsIdx);
-            if (name.isEmpty()) return name;
+            if (name.isEmpty()) {
+                return name;
+            }
         }
         boolean foundConst = false, simpleType = true;
         String prefix = null;

--- a/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/InfoMap.java
@@ -187,15 +187,14 @@ public class InfoMap extends HashMap<String,List<Info>> {
         }
         if (untemplate) {
             // Remove template arguments in the last NS component only, and not in parameters, if any
-            Templates.SplitResult comps = Templates.splitNamespace(name);
-            int last = comps.size()-1;
-            String lastComp = comps.get(last);
-            comps.set(last, Templates.strip(lastComp));
+            List<String> comps = Templates.splitNamespace(name, true);
+            int paramsIdx = comps.size() - 1;
+            String lastComp = comps.get(paramsIdx - 1);
+            comps.set(paramsIdx - 1, Templates.strip(lastComp));
             name = comps.get(0);
-            for (int i = 1; i <= last; i++)
-              name += "::" + comps.get(i);
-            if (comps.parameterList != null)
-                name += comps.parameterList;
+            for (int i = 1; i < paramsIdx; i++)
+                name += "::" + comps.get(i);
+            name += comps.get(paramsIdx);
             if (name.isEmpty()) return name;
         }
         boolean foundConst = false, simpleType = true;

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -2512,7 +2512,12 @@ public class Parser {
 
         type = functionAfter(context, decl, dcl, type);
         context = new Context(context);
-        context.virtualize = (context.virtualize && type.virtual) || (info != null && info.virtualize);
+
+        // Virtualize the function if class is virtualized and C++ function is virtual
+        // or if function is explicitly virtualized with info.
+        // Exclude constructor case since we may have looked up the info of the class in lieu of
+        // the info of the constructor, and constructors cannot be virtualized.
+        context.virtualize = (context.virtualize && type.virtual) || (info != null && info.virtualize && !type.constructor);
 
         List<Declarator> prevDcl = new ArrayList<Declarator>();
         boolean first = true;

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -990,19 +990,20 @@ public class Parser {
 
         // perform template substitution
         if (context.templateMap != null) {
-            Templates.SplitResult types = Templates.splitNamespace(type.cppName);
+            List<String> types = Templates.splitNamespace(type.cppName, true);
             String separator = "";
             type.cppName = "";
             List<Type> arguments = new ArrayList<>();
-            for (String t : types) {
-                Type t2 = context.templateMap.get(t);
-                type.cppName += separator + (t2 != null ? t2.cppName : t);
+            int paramsIdx = types.size() - 1;
+            for (int i = 0; i < paramsIdx; i++) {
+                Type t2 = context.templateMap.get(types.get(i));
+                type.cppName += separator + (t2 != null ? t2.cppName : types.get(i));
                 if (t2 != null && t2.arguments != null) {
                     arguments.addAll(Arrays.asList(t2.arguments));
                 }
                 separator = "::";
             }
-            if (types.parameterList != null) type.cppName += types.parameterList;
+            type.cppName += types.get(paramsIdx);
             if (arguments.size() > 0) {
                 type.arguments = arguments.toArray(new Type[0]);
             }
@@ -2154,15 +2155,16 @@ public class Parser {
                     // perform template substitution
                     String cppName = token.value;
                     if (context.templateMap != null) {
-                        Templates.SplitResult types = Templates.splitNamespace(cppName);
+                        List<String> types = Templates.splitNamespace(cppName, true);
                         String separator = "";
                         cppName = "";
-                        for (String t : types) {
-                            Type t2 = context.templateMap.get(t);
-                            cppName += separator + (t2 != null ? t2.cppName : t);
+                        int paramsIdx = types.size() - 1;
+                        for (int i = 0; i < paramsIdx; i++) {
+                            Type t2 = context.templateMap.get(types.get(i));
+                            cppName += separator + (t2 != null ? t2.cppName : types.get(i));
                             separator = "::";
                         }
-                        if (types.parameterList != null) cppName += types.parameterList;
+                        cppName += types.get(paramsIdx);
                     }
 
                     // try to qualify all the identifiers

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -2439,9 +2439,6 @@ public class Parser {
             // with the class info. Kept for now for backwards compatibility.
             if (info == null) {
                 info = infoMap.getFirst(dcl.cppName + templateArgs);
-                if (info == null && !templateArgs.isEmpty()) {
-                    info = infoMap.getFirst(dcl.cppName);
-                }
             }
             if (!type.constructor && !type.destructor && !type.operator && (context.templateMap == null || context.templateMap.full())) {
                 infoMap.put(info != null ? new Info(info).cppNames(fullname).javaNames(null) : new Info(fullname));

--- a/src/main/java/org/bytedeco/javacpp/tools/TemplateMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/TemplateMap.java
@@ -71,16 +71,17 @@ class TemplateMap extends LinkedHashMap<String,Type> {
 
     @Override
     public String toString() {
-        String res = "<";
-        for (Map.Entry<String, Type> e: entrySet()) {
-            if (res.length() > 1) res += ",";
+        String s = "<";
+        for (Map.Entry<String, Type> e : entrySet()) {
+            if (s.length() > 1) {
+                s += ",";
+            }
             Type t = e.getValue();
-            if (t == null)
-                res += e.getKey();
-            else
-                res += t.cppName;
+            s += t != null ? t.cppName : e.getKey();
         }
-        if (res.charAt(res.length()-1) == '>') res += " ";
-        return res + ">";
+        if (s.endsWith(">")) {
+            s += " ";
+        }
+        return s + ">";
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/TemplateMap.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/TemplateMap.java
@@ -23,6 +23,7 @@
 package org.bytedeco.javacpp.tools;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *
@@ -66,5 +67,20 @@ class TemplateMap extends LinkedHashMap<String,Type> {
         } else {
             return value;
         }
+    }
+
+    @Override
+    public String toString() {
+        String res = "<";
+        for (Map.Entry<String, Type> e: entrySet()) {
+            if (res.length() > 1) res += ",";
+            Type t = e.getValue();
+            if (t == null)
+                res += e.getKey();
+            else
+                res += t.cppName;
+        }
+        if (res.charAt(res.length()-1) == '>') res += " ";
+        return res + ">";
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Templates.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Templates.java
@@ -47,6 +47,7 @@ class Templates {
         return strip(s).length() == s.length();
     }
 
+    /** Returns {@code splitNamespace(s, false)}. */
     static List<String> splitNamespace(String s) {
         return splitNamespace(s, false);
     }
@@ -75,10 +76,13 @@ class Templates {
             int count = 1;
             for (pIndex--; pIndex >= 0; pIndex--) {
                 char c = sTemplatesMasked.charAt(pIndex);
-                if (c == ')') count++;
-                else if (c == '(') {
+                if (c == ')') {
+                    count++;
+                } else if (c == '(') {
                     count--;
-                    if (count == 0) break;
+                    if (count == 0) {
+                        break;
+                    }
                 }
             }
         }
@@ -100,7 +104,9 @@ class Templates {
             comps.add(s.substring(start));
             params = "";
         }
-        if (returnParams) comps.add(params);
+        if (returnParams) {
+            comps.add(params);
+        }
         return comps;
     }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Templates.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Templates.java
@@ -47,12 +47,16 @@ class Templates {
         return strip(s).length() == s.length();
     }
 
-    static class SplitResult extends ArrayList<String> {
-        String parameterList;
+    static List<String> splitNamespace(String s) {
+        return splitNamespace(s, false);
     }
 
-    /** Split s at ::, but taking care of qualified template arguments and qualified function parameters, if any. */
-    static SplitResult splitNamespace(String s) {
+    /**
+     * Split s at ::, but taking care of qualified template arguments and qualified function parameters.
+     * If returnParams is true, returned list contains an extra element with function parameters, or the empty
+     * string if none are present.
+     */
+    static List<String> splitNamespace(String s, boolean returnParams) {
         String sTemplatesMasked = s;
         for (;;) {
             Matcher m = templatePattern.matcher(sTemplatesMasked);
@@ -64,7 +68,7 @@ class Templates {
                 break;
             }
         }
-        SplitResult comps = new SplitResult();
+        ArrayList<String> comps = new ArrayList<>();
         int pIndex = sTemplatesMasked.lastIndexOf(')'); // last because of function pointer types like void(*)()
         if (pIndex > 0) {
             // Pointer list may contain function pointer types with parentheses
@@ -88,12 +92,15 @@ class Templates {
                 break;
             }
         }
+        String params;
         if (pIndex >= 0) {
             comps.add(s.substring(start, pIndex));
-            comps.parameterList = s.substring(pIndex);
+            params = s.substring(pIndex);
         } else {
             comps.add(s.substring(start));
+            params = "";
         }
+        if (returnParams) comps.add(params);
         return comps;
     }
 }


### PR DESCRIPTION
See Issue #729 

* Add `Parser.operator` that explicitly parses an operator following the `operator` keyword.  In master, all tokens up to next open parenthesis were taken as the operator name. We need this to be able to parse template arguments that may appear after the operator and before a parenthesis .
* Add support for function parameters to `Templates.splitNamespace`.
* Make `Infomap.normalize` use methods in `Templates` to untemplate. This allows to untemplate things like `operator<<double>`.
* Fix construction of `fullname` in `Parser.function` to insert the function template arguments. 
* Clarify distinction between constructor calling name `NS::C` and declaration name `NS::C::C`. We cannot specify template arguments of constructor templates with calling name, so info keys should use the declaration name. We still query the calling name for backwards compatibility when generating a constructor template instance, but we query only the declaration name when looking for template instances in `DeclarationList.add`. This fixes a bug where template arguments of the class were used instead of template arguments of the constructor when both were templated.
* Fix a bug where the cppName of constructor was set to the declaration name in the particular case of the class lying in root namespace.

Example  derived from @benshiffman's:

```c++
template <typename T>
class TemplatedClass {
public:
    template <typename U> TemplatedClass(U val);
    template <typename U> void funTemp(U val);
    template <typename U> bool operator<(TemplatedClass<U>& rhs);
};
```

WIth info:
```Java
infoMap
    .put(new Info("TemplatedClass<double>").pointerTypes("TemplatedClassDouble"))

    .put(new Info("TemplatedClass<double>::TemplatedClass<int>").javaNames("XXX"))

    .put(new Info("TemplatedClass<double>::funTemp<int>").javaNames("funTempInt"))

    .put(new Info("TemplatedClass<double>::operator <<double>").javaNames("lt"))
;
```

we now get:
```Java
    public TemplatedClassDouble(int val) { super((Pointer)null); allocate(val); }
    private native void allocate(int val);
    public native @Name("funTemp<int>") void funTempInt(int val);
    public native @Cast("bool") @Name("operator <<double>") boolean lt(@ByRef TemplatedClassDouble rhs);
```

Note that `.javaNames("XXX")` is necessary because in `DeclarationList.add` we require a Java name to be present in the info to trigger the template instantiation. This doesn't make sense for constructors. Maybe should we also accept info with `define`, and `javaText`. Or maybe remove any constraint on what is in the info (not tested).

If, because of polymorphism, we need to target functions with specific arguments, things get a bit more complicated:
```Java
infoMap
     .put(new Info("TemplatedClass<double>").pointerTypes("TemplatedClassDouble"))

     .put(new Info("TemplatedClass<double>::TemplatedClass<int>(U)").javaNames("XXX"))

     .put(new Info("TemplatedClass<double>::funTemp<int>(U)").javaNames("XXX"))
     .put(new Info("TemplatedClass<double>::funTemp<int>(int)").javaNames("funTempInt"))

     .put(new Info("TemplatedClass<double>::operator <<double>(TemplatedClass<U>&)").javaNames("XXX"))
     .put(new Info("TemplatedClass<double>::operator <<double>(TemplatedClass<double>&)").javaNames("lt"))
;
```
The use of placeholder `U` is a bit ugly, but I don't think we can do much about it. It's necessary to answer the infoMap queries in `DeclarationList.add`, like `TemplatedClass<double>::funTemp<U>(U)`. `TemplatedClass<double>::funTemp<int>(U)` matches, but not `TemplatedClass<double>::funTemp<int>(int)`.

`Info("TemplatedClass<double>::funTemp<int>(int)").javaNames("funTempInt")` is still necessary if we need to set the `javaName` because when we generate the function instance, the infoMap is queried with the function fullname, with template arguments replaced by their concrete values, and `TemplatedClass<double>::funTemp<int>(U)` won't match.

This PR should only introduce one breaking change: info keys using calling name of templated constructor won't match anymore and must be changed to use declaration name. 

Regression tests:
* pytorch: two infos for constructor template using calling names must be changed.
* bullet: this PR generates one less constructor for `btDefaultMotionState` for a complex reason. This class has a `virtualize` info and a constructor with parameters having default values.
  - in master, because of the bug mentioned above and because the class lies in root namespace, the info map for the constructor is queried with the declaration name only and doesn't match the class info with `virtualize`.
  - with PR, constructor cppName is correct, and infomap is queries first with declaration name, then with calling (class) name. So `virtualize` is (wrongly) set to true for the constructor and since function overloads are not generated for virtualized functions, the no-arg constructor is not generated.
`virtualize` info doesn't make sense for constructors. Does it ?
If it does not, I suggest to ignore this info for constructors, which should avoid this problem related to a confusion between constructor info and class info.
* all other presets: no change
* presets not checked: libfreenect2,chilitags,hyperscan,tensorflow,ale, ngraph, qt, skia, videoinput
