### PR TITLE
Untemplate class name before adding them to infoMap

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3657,7 +3657,10 @@ public class Parser {
             if (type.javaName.length() > 0 && context.javaName != null) {
                 type.javaName = context.javaName + "." + type.javaName;
             }
-            infoMap.put(info = new Info(type.cppName).pointerTypes(type.javaName));
+            // Adding this info allows proper ns resolution for next declarations, but
+            // we don't want it to trigger template instantiation, so we untemplate the
+            // name first.
+            infoMap.put(info = new Info(Templates.strip(type.cppName)).pointerTypes(type.javaName));
         }
 
         /* Propagate the need for downcasting from base classes */


### PR DESCRIPTION
Parsing this:
```c++
template <class T>
struct S<T, T>  {};
```
generates a `S<T,T>.java` class.

When it's parsed the first time, and no info is found for the class, it adds a dummy one for `S<T,T>`. 
I think this adding is to allow proper namespace resolution if `S` is referenced afterwards.
But when `DeclarationList.add` is called, the query that looks for template instances in info map returns `S<T,T>` and triggers the instantiation.

I suggest to untemplate the name of the class before adding it to the infoMap, in order to still help namespace resolution but prevent spurious template instantiation.
Does it make sense ?