### PR TITLE
Support anonymous template parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Let `Parser` support templates with unnamed type parameters ([pull #742](https://github.com/bytedeco/javacpp/pull/742))
  * Prevent `Parser` from producing duplicate declarations for basic containers ([pull #741](https://github.com/bytedeco/javacpp/pull/741))
 
 ### January 29, 2024 version 1.5.10

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -654,6 +654,8 @@ public class Parser {
                     String key = t.value;
                     map.put(key, map.get(key));
                     token = tokens.next();
+                } else {
+                    map.put("[" + (map.size() + 1) + "]", null); // Anonymous type
                 }
             } else if (token.match(Token.IDENTIFIER)) {
                 Type type = type(context); // ignore?

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -655,7 +655,7 @@ public class Parser {
                     map.put(key, map.get(key));
                     token = tokens.next();
                 } else {
-                    map.put("[" + (map.size() + 1) + "]", null); // Anonymous type
+                    map.put("typename arg" + map.size(), null); // Anonymous type
                 }
             } else if (token.match(Token.IDENTIFIER)) {
                 Type type = type(context); // ignore?


### PR DESCRIPTION
Add support for anonymous type template parameters, such as:
```c++
template <typename ModuleType, typename>
```
We use a dummy name `[2]` as a key in the template map. If we used `null` or the empty string, we couldn't have more than 1 anonymous parameter.

Regression tests: no change in existing presets.