### PR TITLE
fix: std::char_traits is deprecated for other type than char

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -1041,7 +1041,7 @@ public class Generator {
             out.println("    if (ptr == NULL) {");
             out.println("        return NULL;");
             out.println("    }");
-            out.println("    return JavaCPP_createStringFromUTF16(env, ptr, std::char_traits<unsigned short>::length(ptr));");
+            out.println("    return JavaCPP_createStringFromUTF16(env, ptr, strlen(reinterpret_cast<const char*>(ptr)));");
             out.println("}");
             out.println();
         }


### PR DESCRIPTION
Issue was the following:

`jniNativeLibrary.cpp:314:57: warning: 'char_traits<unsigned short>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it. [-Wdeprecated-declarations]
    return JavaCPP_createStringFromUTF16(env, ptr, std::char_traits<unsigned short>::length(ptr));
                                                        ^
char_traits.h:79:8: note: 'char_traits<unsigned short>' has been explicitly marked deprecated here
struct _LIBCPP_DEPRECATED_("char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it.")
       ^
c++/v1/__config:772:53: note: expanded from macro '_LIBCPP_DEPRECATED_'
#      define _LIBCPP_DEPRECATED_(m) __attribute__((deprecated(m)))`