### PR TITLE
Update the Gradle snippet for Kotlin DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ We can also have everything downloaded and installed automatically with:
   </dependency>
 ```
 
- * Gradle (inside the `build.gradle` file)
+ * Gradle (inside the `build.gradle.kts` or `build.gradle` file)
 ```groovy
   dependencies {
-    implementation group: 'org.bytedeco', name: 'javacpp', version: '1.5.10'
+    implementation("org.bytedeco:javacpp:1.5.10")
   }
 ```
 


### PR DESCRIPTION
Gradle now recommends to use Kotlin DSL over Groovy DSL. This updates the dependency snippet for Gradle to be compatible with both.