### PR TITLE
Add libomp to windows preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Bundle `libomp` from Visual Studio to fix presets using OpenMP on Windows ([pull #755](https://github.com/bytedeco/javacpp/pull/755))
  * Fix inconsistencies when using `@Platform(inherit=..., library=...)` together ([pull #747](https://github.com/bytedeco/javacpp/pull/747))
  * Let `Parser` support templates with unnamed type parameters ([pull #742](https://github.com/bytedeco/javacpp/pull/742))
  * Prevent `Parser` from producing duplicate declarations for basic containers ([pull #741](https://github.com/bytedeco/javacpp/pull/741))

--- a/src/main/java/org/bytedeco/javacpp/presets/javacpp.java
+++ b/src/main/java/org/bytedeco/javacpp/presets/javacpp.java
@@ -50,21 +50,19 @@ import org.bytedeco.javacpp.annotation.Properties;
                        "api-ms-win-core-sysinfo-l1-1-0", "api-ms-win-core-synch-l1-2-0", "api-ms-win-core-console-l1-1-0", "api-ms-win-core-debug-l1-1-0",
                        "api-ms-win-core-rtlsupport-l1-1-0", "api-ms-win-core-processthreads-l1-1-1", "api-ms-win-core-file-l1-2-0", "api-ms-win-core-profile-l1-1-0",
                        "api-ms-win-core-memory-l1-1-0", "api-ms-win-core-util-l1-1-0", "api-ms-win-core-interlocked-l1-1-0", "ucrtbase",
-                       "vcruntime140", "vcruntime140_1", "msvcp140", "msvcp140_1", "concrt140", "vcomp140"}
+                       "vcruntime140", "vcruntime140_1", "msvcp140", "msvcp140_1", "concrt140", "vcomp140", "libomp140.i386", "libomp140.x86_64"}
         ),
         @Platform(
             value = "windows-x86",
             preloadpath = {"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x86/Microsoft.VC140.CRT/",
                            "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x86/Microsoft.VC140.OpenMP/",
-                           "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x86/"},
-            preload = {"libomp140.i386"}
+                           "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x86/"}
         ),
         @Platform(
             value = "windows-x86_64",
             preloadpath = {"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.CRT/",
                            "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.OpenMP/",
-                           "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64/"},
-            preload = {"libomp140.x86_64"}
+                           "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64/"}
         ),
     },
     global = "org.bytedeco.javacpp.presets.javacpp"

--- a/src/main/java/org/bytedeco/javacpp/presets/javacpp.java
+++ b/src/main/java/org/bytedeco/javacpp/presets/javacpp.java
@@ -56,13 +56,15 @@ import org.bytedeco.javacpp.annotation.Properties;
             value = "windows-x86",
             preloadpath = {"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x86/Microsoft.VC140.CRT/",
                            "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x86/Microsoft.VC140.OpenMP/",
-                           "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x86/"}
+                           "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x86/"},
+            preload = {"libomp140.i386"}
         ),
         @Platform(
             value = "windows-x86_64",
             preloadpath = {"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.CRT/",
                            "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.OpenMP/",
-                           "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64/"}
+                           "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64/"},
+            preload = {"libomp140.x86_64"}
         ),
     },
     global = "org.bytedeco.javacpp.presets.javacpp"


### PR DESCRIPTION
Add `libomp140` to the list of windows preload. This is the LLVM openMP runtime, which brings compatibility with OpenMP 3 and should become the standard for VS in replacement of `vsomp`.

Needed by Pytorch since 2.2.2.

Fixes bytedeco/javacpp-presets#1500.