### PR TITLE
Add mapping for `std::chrono`

### DIFF
--- a/.github/workflows/javacpp.yml
+++ b/.github/workflows/javacpp.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   ios-arm64:
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   ios-x86_64:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
 #  linux-armhf:
@@ -56,11 +56,11 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   macosx-arm64:
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   macosx-x86_64:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       CI_DEPLOY_OPTIONS: "" # to not skip tests
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add minimal mappings for `std::chrono` from C++11 ([pull #766](https://github.com/bytedeco/javacpp/pull/766))
  * Let `Parser` annotate Java constructors with `@Deprecated` when appropriate ([pull #757](https://github.com/bytedeco/javacpp/pull/757))
  * Add to `InfoMap.defaults` more names that are reserved in Java, but not in C++ ([pull #757](https://github.com/bytedeco/javacpp/pull/757))
  * Bundle `libomp` from Visual Studio to fix presets using OpenMP on Windows ([pull #755](https://github.com/bytedeco/javacpp/pull/755))

--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,7 @@ Import-Package: \
                 <argument>-Dplatform.compiler=${javacpp.platform.compiler}</argument>
                 <argument>org.bytedeco.javacpp.Pointer</argument>
                 <argument>org.bytedeco.javacpp.presets.javacpp</argument>
+                <argument>org.bytedeco.javacpp.chrono.*</argument>
                 <argument>-mod</argument>
                 <argument>${project.build.directory}/generated-sources/java9/module-info.java</argument>
               </arguments>

--- a/src/main/java/org/bytedeco/javacpp/chrono/Chrono.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Chrono.java
@@ -1,0 +1,4 @@
+package org.bytedeco.javacpp.chrono;
+
+public class Chrono {
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/Chrono.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Chrono.java
@@ -1,4 +1,7 @@
 package org.bytedeco.javacpp.chrono;
 
+import org.bytedeco.javacpp.annotation.Properties;
+
+@Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class Chrono {
 }

--- a/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionClock.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionClock.java
@@ -6,7 +6,7 @@ import org.bytedeco.javacpp.annotation.MemberGetter;
 import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Properties;
 
-@Name("std::chrono::high_resolution_clock") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::high_resolution_clock") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class HighResolutionClock extends Pointer {
     static public native @ByVal HighResolutionTime now();
     static public native @MemberGetter boolean is_steady();

--- a/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionClock.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionClock.java
@@ -8,6 +8,6 @@ import org.bytedeco.javacpp.annotation.Properties;
 
 @Name("std::chrono::high_resolution_clock") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
 public class HighResolutionClock extends Pointer {
-    static public native @ByVal SystemTime now();
+    static public native @ByVal HighResolutionTime now();
     static public native @MemberGetter boolean is_steady();
 }

--- a/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionClock.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionClock.java
@@ -1,0 +1,13 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.ByVal;
+import org.bytedeco.javacpp.annotation.MemberGetter;
+import org.bytedeco.javacpp.annotation.Name;
+import org.bytedeco.javacpp.annotation.Properties;
+
+@Name("std::chrono::high_resolution_clock") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class HighResolutionClock extends Pointer {
+    static public native @ByVal SystemTime now();
+    static public native @MemberGetter boolean is_steady();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionDuration.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionDuration.java
@@ -1,0 +1,27 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::high_resolution_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class HighResolutionDuration extends Pointer {
+    public HighResolutionDuration() { allocate(); }
+    private native void allocate();
+    public HighResolutionDuration(long r) { allocate(r); }
+    private native void allocate(long r);
+
+    public native @Name("operator=") @ByRef HighResolutionDuration put(@Const @ByRef HighResolutionDuration other);
+    public native @Name("operator-") @ByVal HighResolutionDuration negate();
+    public native @Name("operator++") @ByRef HighResolutionDuration increment();
+    public native @Name("operator--") @ByRef HighResolutionDuration decrement();
+    public native @Name("operator+=") @ByRef HighResolutionDuration addPut(@Const @ByRef HighResolutionDuration d);
+    public native @Name("operator-=") @ByRef HighResolutionDuration subtractPut(@Const @ByRef HighResolutionDuration d);
+    public native @Name("operator*=") @ByRef HighResolutionDuration multiplyPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef HighResolutionDuration modPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef HighResolutionDuration modPut(@Const @ByRef HighResolutionDuration rhs);
+
+    public native long count();
+    static public native @ByVal @Name("zero") HighResolutionDuration zero_();
+    static public native @ByVal HighResolutionDuration min();
+    static public native @ByVal HighResolutionDuration max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionDuration.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionDuration.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::high_resolution_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::high_resolution_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class HighResolutionDuration extends Pointer {
     public HighResolutionDuration() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionTime.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionTime.java
@@ -8,8 +8,8 @@ public class HighResolutionTime extends Pointer {
     public HighResolutionTime() { allocate(); }
     private native void allocate();
 
-    public HighResolutionTime(SystemDuration d) { allocate(d); }
-    private native void allocate(@Const @ByRef SystemDuration d);
+    public HighResolutionTime(HighResolutionDuration d) { allocate(d); }
+    private native void allocate(@Const @ByRef HighResolutionDuration d);
 
     public native @ByVal HighResolutionTime time_since_epoch();
 

--- a/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionTime.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionTime.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::time_point<std::chrono::high_resolution_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::time_point<std::chrono::high_resolution_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class HighResolutionTime extends Pointer {
     public HighResolutionTime() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionTime.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/HighResolutionTime.java
@@ -1,0 +1,20 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::time_point<std::chrono::high_resolution_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class HighResolutionTime extends Pointer {
+    public HighResolutionTime() { allocate(); }
+    private native void allocate();
+
+    public HighResolutionTime(SystemDuration d) { allocate(d); }
+    private native void allocate(@Const @ByRef SystemDuration d);
+
+    public native @ByVal HighResolutionTime time_since_epoch();
+
+    public native @Name("operator +=") @ByRef HighResolutionTime addPut(@Const @ByRef HighResolutionDuration d);
+    public native @Name("operator -=") @ByRef HighResolutionTime subtractPut(@Const @ByRef HighResolutionDuration d);
+    static public native @ByVal HighResolutionTime min();
+    static public native @ByVal HighResolutionTime max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/Hours.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Hours.java
@@ -1,0 +1,27 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::hours") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class Hours extends Pointer {
+    public Hours() { allocate(); }
+    private native void allocate();
+    public Hours(long r) { allocate(r); }
+    private native void allocate(long r);
+
+    public native @Name("operator=") @ByRef Hours put(@Const @ByRef Hours other);
+    public native @Name("operator-") @ByVal Hours negate();
+    public native @Name("operator++") @ByRef Hours increment();
+    public native @Name("operator--") @ByRef Hours decrement();
+    public native @Name("operator+=") @ByRef Hours addPut(@Const @ByRef Hours d);
+    public native @Name("operator-=") @ByRef Hours subtractPut(@Const @ByRef Hours d);
+    public native @Name("operator*=") @ByRef Hours multiplyPut(@Const @ByRef int rhs);
+    public native @Name("operator%=") @ByRef Hours modPut(@Const @ByRef int rhs);
+    public native @Name("operator%=") @ByRef Hours modPut(@Const @ByRef Hours rhs);
+
+    public native int count();
+    static public native @ByVal @Name("zero") Hours zero_();
+    static public native @ByVal Hours min();
+    static public native @ByVal Hours max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/Hours.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Hours.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::hours") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::hours") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class Hours extends Pointer {
     public Hours() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/Microseconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Microseconds.java
@@ -1,0 +1,36 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::microseconds") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class Microseconds extends Pointer {
+    public Microseconds() { allocate(); }
+    private native void allocate();
+    public Microseconds(long r) { allocate(r); }
+    private native void allocate(long r);
+
+    public Microseconds(Milliseconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Milliseconds d);
+    public Microseconds(Seconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Seconds d);
+    public Microseconds(Minutes d) { allocate(d); }
+    private native void allocate(@Const @ByRef Minutes d);
+    public Microseconds(Hours d) { allocate(d); }
+    private native void allocate(@Const @ByRef Hours d);
+
+    public native @Name("operator=") @ByRef Microseconds put(@Const @ByRef Microseconds other);
+    public native @Name("operator-") @ByVal Microseconds negate();
+    public native @Name("operator++") @ByRef Microseconds increment();
+    public native @Name("operator--") @ByRef Microseconds decrement();
+    public native @Name("operator+=") @ByRef Microseconds addPut(@Const @ByRef Microseconds d);
+    public native @Name("operator-=") @ByRef Microseconds subtractPut(@Const @ByRef Microseconds d);
+    public native @Name("operator*=") @ByRef Microseconds multiplyPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef Microseconds modPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef Microseconds modPut(@Const @ByRef Microseconds rhs);
+
+    public native long count();
+    static public native @ByVal @Name("zero") Microseconds zero_();
+    static public native @ByVal Microseconds min();
+    static public native @ByVal Microseconds max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/Microseconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Microseconds.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::microseconds") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::microseconds") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class Microseconds extends Pointer {
     public Microseconds() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/Milliseconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Milliseconds.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::milliseconds") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::milliseconds") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class Milliseconds extends Pointer {
     public Milliseconds() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/Milliseconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Milliseconds.java
@@ -1,0 +1,33 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::milliseconds") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class Milliseconds extends Pointer {
+    public Milliseconds() { allocate(); }
+    private native void allocate();
+    public Milliseconds(long r) { allocate(r); }
+    private native void allocate(long r);
+    public Milliseconds(Seconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Seconds d);
+    public Milliseconds(Minutes d) { allocate(d); }
+    private native void allocate(@Const @ByRef Minutes d);
+    public Milliseconds(Hours d) { allocate(d); }
+    private native void allocate(@Const @ByRef Hours d);
+
+    public native @Name("operator=") @ByRef Milliseconds put(@Const @ByRef Milliseconds other);
+    public native @Name("operator-") @ByVal Milliseconds negate();
+    public native @Name("operator++") @ByRef Milliseconds increment();
+    public native @Name("operator--") @ByRef Milliseconds decrement();
+    public native @Name("operator+=") @ByRef Milliseconds addPut(@Const @ByRef Milliseconds d);
+    public native @Name("operator-=") @ByRef Milliseconds subtractPut(@Const @ByRef Milliseconds d);
+    public native @Name("operator*=") @ByRef Milliseconds multiplyPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef Milliseconds modPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef Milliseconds modPut(@Const @ByRef Milliseconds rhs);
+
+    public native long count();
+    static public native @ByVal @Name("zero") Milliseconds zero_();
+    static public native @ByVal Milliseconds min();
+    static public native @ByVal Milliseconds max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/Minutes.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Minutes.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::minutes") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::minutes") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class Minutes extends Pointer {
     public Minutes() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/Minutes.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Minutes.java
@@ -1,0 +1,29 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::minutes") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class Minutes extends Pointer {
+    public Minutes() { allocate(); }
+    private native void allocate();
+    public Minutes(long r) { allocate(r); }
+    private native void allocate(long r);
+    public Minutes(Hours d) { allocate(d); }
+    private native void allocate(@Const @ByRef Hours d);
+
+    public native @Name("operator=") @ByRef Minutes put(@Const @ByRef Minutes other);
+    public native @Name("operator-") @ByVal Minutes negate();
+    public native @Name("operator++") @ByRef Minutes increment();
+    public native @Name("operator--") @ByRef Minutes decrement();
+    public native @Name("operator+=") @ByRef Minutes addPut(@Const @ByRef Minutes d);
+    public native @Name("operator-=") @ByRef Minutes subtractPut(@Const @ByRef Minutes d);
+    public native @Name("operator*=") @ByRef Minutes multiplyPut(@Const @ByRef int rhs);
+    public native @Name("operator%=") @ByRef Minutes modPut(@Const @ByRef int rhs);
+    public native @Name("operator%=") @ByRef Minutes modPut(@Const @ByRef Minutes rhs);
+
+    public native int count();
+    static public native @ByVal @Name("zero") Minutes zero_();
+    static public native @ByVal Minutes min();
+    static public native @ByVal Minutes max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/Nanoseconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Nanoseconds.java
@@ -1,0 +1,37 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::nanoseconds") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class Nanoseconds extends Pointer {
+    public Nanoseconds() { allocate(); }
+    private native void allocate();
+    public Nanoseconds(long r) { allocate(r); }
+    private native void allocate(long r);
+    public Nanoseconds(Microseconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Microseconds d);
+    public Nanoseconds(Milliseconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Milliseconds d);
+    public Nanoseconds(Seconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Seconds d);
+    public Nanoseconds(Minutes d) { allocate(d); }
+    private native void allocate(@Const @ByRef Minutes d);
+    public Nanoseconds(Hours d) { allocate(d); }
+    private native void allocate(@Const @ByRef Hours d);
+
+    public native @Name("operator=") @ByRef Nanoseconds put(@Const @ByRef Nanoseconds other);
+    public native @Name("operator-") @ByVal Nanoseconds negate();
+    public native @Name("operator++") @ByRef Nanoseconds increment();
+    public native @Name("operator--") @ByRef Nanoseconds decrement();
+    public native @Name("operator+=") @ByRef Nanoseconds addPut(@Const @ByRef Nanoseconds d);
+    public native @Name("operator-=") @ByRef Nanoseconds subtractPut(@Const @ByRef Nanoseconds d);
+    public native @Name("operator*=") @ByRef Nanoseconds multiplyPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef Nanoseconds modPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef Nanoseconds modPut(@Const @ByRef Nanoseconds rhs);
+
+    public native long count();
+    static public native @ByVal @Name("zero") Nanoseconds zero_();
+    static public native @ByVal Nanoseconds min();
+    static public native @ByVal Nanoseconds max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/Nanoseconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Nanoseconds.java
@@ -19,6 +19,12 @@ public class Nanoseconds extends Pointer {
     private native void allocate(@Const @ByRef Minutes d);
     public Nanoseconds(Hours d) { allocate(d); }
     private native void allocate(@Const @ByRef Hours d);
+    public Nanoseconds(SystemDuration d) {  super((Pointer)null); allocate(d); };
+    private native void allocate(@Const @ByRef SystemDuration d);
+    public Nanoseconds(HighResolutionDuration d) {  super((Pointer)null); allocate(d); };
+    private native void allocate(@Const @ByRef HighResolutionDuration d);
+    public Nanoseconds(SteadyDuration d) {  super((Pointer)null); allocate(d); };
+    private native void allocate(@Const @ByRef SteadyDuration d);
 
     public native @Name("operator=") @ByRef Nanoseconds put(@Const @ByRef Nanoseconds other);
     public native @Name("operator-") @ByVal Nanoseconds negate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/Nanoseconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Nanoseconds.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::nanoseconds") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::nanoseconds") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class Nanoseconds extends Pointer {
     public Nanoseconds() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/Seconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Seconds.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::seconds") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::seconds") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class Seconds extends Pointer {
     public Seconds() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/Seconds.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/Seconds.java
@@ -1,0 +1,31 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::seconds") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class Seconds extends Pointer {
+    public Seconds() { allocate(); }
+    private native void allocate();
+    public Seconds(long r) { allocate(r); }
+    private native void allocate(long r);
+    public Seconds(Minutes d) { allocate(d); }
+    private native void allocate(@Const @ByRef Minutes d);
+    public Seconds(Hours d) { allocate(d); }
+    private native void allocate(@Const @ByRef Hours d);
+
+    public native @Name("operator=") @ByRef Seconds put(@Const @ByRef Seconds other);
+    public native @Name("operator-") @ByVal Seconds negate();
+    public native @Name("operator++") @ByRef Seconds increment();
+    public native @Name("operator--") @ByRef Seconds decrement();
+    public native @Name("operator+=") @ByRef Seconds addPut(@Const @ByRef Seconds d);
+    public native @Name("operator-=") @ByRef Seconds subtractPut(@Const @ByRef Seconds d);
+    public native @Name("operator*=") @ByRef Seconds multiplyPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef Seconds modPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef Seconds modPut(@Const @ByRef Seconds rhs);
+
+    public native long count();
+    static public native @ByVal @Name("zero") Seconds zero_();
+    static public native @ByVal Seconds min();
+    static public native @ByVal Seconds max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SecondsDouble.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SecondsDouble.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::duration<double>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::duration<double>") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class SecondsDouble extends Pointer {
     public SecondsDouble() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/SecondsDouble.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SecondsDouble.java
@@ -1,0 +1,29 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::duration<double>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class SecondsDouble extends Pointer {
+    public SecondsDouble() { allocate(); }
+    private native void allocate();
+    public SecondsDouble(double r) { allocate(r); }
+    private native void allocate(double r);
+    public SecondsDouble(Nanoseconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Nanoseconds d);
+    public SecondsDouble(Seconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Seconds d);
+
+    public native @Name("operator=") @ByRef SecondsDouble put(@Const @ByRef SecondsDouble other);
+    public native @Name("operator-") @ByVal SecondsDouble negate();
+    public native @Name("operator++") @ByRef SecondsDouble increment();
+    public native @Name("operator--") @ByRef SecondsDouble decrement();
+    public native @Name("operator+=") @ByRef SecondsDouble addPut(@Const @ByRef SecondsDouble d);
+    public native @Name("operator-=") @ByRef SecondsDouble subtractPut(@Const @ByRef SecondsDouble d);
+    public native @Name("operator*=") @ByRef SecondsDouble multiplyPut(@Const @ByRef double rhs);
+
+    public native double count();
+    static public native @ByVal @Name("zero") SecondsDouble zero_();
+    static public native @ByVal SecondsDouble min();
+    static public native @ByVal SecondsDouble max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SecondsFloat.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SecondsFloat.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::duration<float>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::duration<float>") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class SecondsFloat extends Pointer {
     public SecondsFloat() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/SecondsFloat.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SecondsFloat.java
@@ -1,0 +1,29 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::duration<float>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class SecondsFloat extends Pointer {
+    public SecondsFloat() { allocate(); }
+    private native void allocate();
+    public SecondsFloat(float r) { allocate(r); }
+    private native void allocate(float r);
+    public SecondsFloat(Nanoseconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Nanoseconds d);
+    public SecondsFloat(Seconds d) { allocate(d); }
+    private native void allocate(@Const @ByRef Seconds d);
+
+    public native @Name("operator=") @ByRef SecondsFloat put(@Const @ByRef SecondsFloat other);
+    public native @Name("operator-") @ByVal SecondsFloat negate();
+    public native @Name("operator++") @ByRef SecondsFloat increment();
+    public native @Name("operator--") @ByRef SecondsFloat decrement();
+    public native @Name("operator+=") @ByRef SecondsFloat addPut(@Const @ByRef SecondsFloat d);
+    public native @Name("operator-=") @ByRef SecondsFloat subtractPut(@Const @ByRef SecondsFloat d);
+    public native @Name("operator*=") @ByRef SecondsFloat multiplyPut(@Const @ByRef float rhs);
+
+    public native float count();
+    static public native @ByVal @Name("zero") SecondsFloat zero_();
+    static public native @ByVal SecondsFloat min();
+    static public native @ByVal SecondsFloat max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SteadyClock.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SteadyClock.java
@@ -5,7 +5,7 @@ import org.bytedeco.javacpp.annotation.ByVal;
 import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Properties;
 
-@Name("std::chrono::steady_clock") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::steady_clock") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class SteadyClock extends Pointer {
     static public native @ByVal SteadyTime now();
 }

--- a/src/main/java/org/bytedeco/javacpp/chrono/SteadyClock.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SteadyClock.java
@@ -1,0 +1,11 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.ByVal;
+import org.bytedeco.javacpp.annotation.Name;
+import org.bytedeco.javacpp.annotation.Properties;
+
+@Name("std::chrono::steady_clock") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class SteadyClock extends Pointer {
+    static public native @ByVal SteadyTime now();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SteadyDuration.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SteadyDuration.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::steady_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::steady_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class SteadyDuration extends Pointer {
     public SteadyDuration() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/SteadyDuration.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SteadyDuration.java
@@ -1,0 +1,26 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::steady_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class SteadyDuration extends Pointer {
+    public SteadyDuration() { allocate(); }
+    private native void allocate();
+    public SteadyDuration(long r) { allocate(r); }
+    private native void allocate(long r);
+
+    public native @Name("operator=") @ByRef SteadyDuration put(@Const @ByRef SteadyDuration other);
+    public native @Name("operator-") @ByVal SteadyDuration negate();
+    public native @Name("operator++") @ByRef SteadyDuration increment();
+    public native @Name("operator--") @ByRef SteadyDuration decrement();
+    public native @Name("operator+=") @ByRef SteadyDuration addPut(@Const @ByRef SteadyDuration d);
+    public native @Name("operator-=") @ByRef SteadyDuration subtractPut(@Const @ByRef SteadyDuration d);
+    public native @Name("operator*=") @ByRef SteadyDuration multiplyPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef SteadyDuration modPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef SteadyDuration modPut(@Const @ByRef SteadyDuration rhs);
+
+    public native long count();
+    static public native @ByVal @Name("zero") SteadyDuration zero_();
+    static public native @ByVal SteadyDuration min();
+    static public native @ByVal SteadyDuration max();}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SteadyTime.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SteadyTime.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::time_point<std::chrono::steady_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::time_point<std::chrono::steady_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class SteadyTime extends Pointer {
     public SteadyTime() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/SteadyTime.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SteadyTime.java
@@ -1,0 +1,21 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::time_point<std::chrono::steady_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class SteadyTime extends Pointer {
+    public SteadyTime() { allocate(); }
+    private native void allocate();
+
+    public SteadyTime(SteadyDuration d) { allocate(d); }
+    private native void allocate(@Const @ByRef SteadyDuration d);
+
+    public native @ByVal SteadyDuration time_since_epoch();
+
+    public native @Name("operator +=") @ByRef SteadyTime addPut(@Const @ByRef SteadyDuration d);
+    public native @Name("operator -=") @ByRef SteadyTime subtractPut(@Const @ByRef SteadyDuration d);
+    static public native @ByVal SteadyTime min();
+    static public native @ByVal SteadyTime max();
+
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SystemClock.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SystemClock.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::system_clock") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::system_clock") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class SystemClock extends Pointer {
     static public native @ByVal SystemTime now();
     static public native @Cast("time_t") long to_time_t(@Const @ByRef SystemTime t);

--- a/src/main/java/org/bytedeco/javacpp/chrono/SystemClock.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SystemClock.java
@@ -1,0 +1,11 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::system_clock") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class SystemClock extends Pointer {
+    static public native @ByVal SystemTime now();
+    static public native @Cast("time_t") long to_time_t(@Const @ByRef SystemTime t);
+    static public native @ByVal SystemTime from_time_t(@Cast("time_t") long t);
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SystemDuration.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SystemDuration.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::system_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::system_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class SystemDuration extends Pointer {
     public SystemDuration() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/chrono/SystemDuration.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SystemDuration.java
@@ -1,0 +1,27 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::system_clock::duration") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class SystemDuration extends Pointer {
+    public SystemDuration() { allocate(); }
+    private native void allocate();
+    public SystemDuration(long r) { allocate(r); }
+    private native void allocate(long r);
+
+    public native @Name("operator=") @ByRef SystemDuration put(@Const @ByRef SystemDuration other);
+    public native @Name("operator-") @ByVal SystemDuration negate();
+    public native @Name("operator++") @ByRef SystemDuration increment();
+    public native @Name("operator--") @ByRef SystemDuration decrement();
+    public native @Name("operator+=") @ByRef SystemDuration addPut(@Const @ByRef SystemDuration d);
+    public native @Name("operator-=") @ByRef SystemDuration subtractPut(@Const @ByRef SystemDuration d);
+    public native @Name("operator*=") @ByRef SystemDuration multiplyPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef SystemDuration modPut(@Const @ByRef long rhs);
+    public native @Name("operator%=") @ByRef SystemDuration modPut(@Const @ByRef SystemDuration rhs);
+
+    public native long count();
+    static public native @ByVal @Name("zero") SystemDuration zero_();
+    static public native @ByVal SystemDuration min();
+    static public native @ByVal SystemDuration max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SystemTime.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SystemTime.java
@@ -1,0 +1,20 @@
+package org.bytedeco.javacpp.chrono;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.annotation.*;
+
+@Name("std::chrono::time_point<std::chrono::system_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+public class SystemTime extends Pointer {
+    public SystemTime() { allocate(); }
+    private native void allocate();
+
+    public SystemTime(SystemDuration d) { allocate(d); }
+    private native void allocate(@Const @ByRef SystemDuration d);
+
+    public native @ByVal SystemDuration time_since_epoch();
+
+    public native @Name("operator +=") @ByRef SystemTime addPut(@Const @ByRef SystemDuration d);
+    public native @Name("operator -=") @ByRef SystemTime subtractPut(@Const @ByRef SystemDuration d);
+    static public native @ByVal SystemTime min();
+    static public native @ByVal SystemTime max();
+}

--- a/src/main/java/org/bytedeco/javacpp/chrono/SystemTime.java
+++ b/src/main/java/org/bytedeco/javacpp/chrono/SystemTime.java
@@ -3,7 +3,7 @@ package org.bytedeco.javacpp.chrono;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.*;
 
-@Name("std::chrono::time_point<std::chrono::system_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.javacpp.class)
+@Name("std::chrono::time_point<std::chrono::system_clock>") @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
 public class SystemTime extends Pointer {
     public SystemTime() { allocate(); }
     private native void allocate();

--- a/src/main/java/org/bytedeco/javacpp/global/chrono.java
+++ b/src/main/java/org/bytedeco/javacpp/global/chrono.java
@@ -1,7 +1,7 @@
-package org.bytedeco.javacpp.chrono;
+package org.bytedeco.javacpp.global;
 
 import org.bytedeco.javacpp.annotation.Properties;
 
 @Properties(inherit = org.bytedeco.javacpp.presets.chrono.class)
-public class Chrono {
+public class chrono {
 }

--- a/src/main/java/org/bytedeco/javacpp/presets/chrono.java
+++ b/src/main/java/org/bytedeco/javacpp/presets/chrono.java
@@ -1,5 +1,6 @@
 package org.bytedeco.javacpp.presets;
 
+import org.bytedeco.javacpp.annotation.Platform;
 import org.bytedeco.javacpp.annotation.Properties;
 import org.bytedeco.javacpp.tools.Info;
 import org.bytedeco.javacpp.tools.InfoMap;
@@ -8,7 +9,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 @Properties(
     inherit = javacpp.class,
     target = "org.bytedeco.javacpp.chrono",
-    global = "org.bytedeco.javacpp.chrono.Chrono"
+    global = "org.bytedeco.javacpp.global.chrono"
 )
 public class chrono implements InfoMapper {
     @Override public void map(InfoMap infoMap) {

--- a/src/main/java/org/bytedeco/javacpp/presets/chrono.java
+++ b/src/main/java/org/bytedeco/javacpp/presets/chrono.java
@@ -1,0 +1,10 @@
+package org.bytedeco.javacpp.presets;
+
+import org.bytedeco.javacpp.annotation.Properties;
+
+@Properties(
+    target = "org.bytedeco.javacpp.chrono",
+    global = "org.bytedeco.javacpp.chrono.Chrono"
+)
+public class chrono {
+}

--- a/src/main/java/org/bytedeco/javacpp/presets/chrono.java
+++ b/src/main/java/org/bytedeco/javacpp/presets/chrono.java
@@ -3,6 +3,7 @@ package org.bytedeco.javacpp.presets;
 import org.bytedeco.javacpp.annotation.Properties;
 
 @Properties(
+    inherit = javacpp.class,
     target = "org.bytedeco.javacpp.chrono",
     global = "org.bytedeco.javacpp.chrono.Chrono"
 )

--- a/src/main/java/org/bytedeco/javacpp/presets/chrono.java
+++ b/src/main/java/org/bytedeco/javacpp/presets/chrono.java
@@ -1,11 +1,39 @@
 package org.bytedeco.javacpp.presets;
 
 import org.bytedeco.javacpp.annotation.Properties;
+import org.bytedeco.javacpp.tools.Info;
+import org.bytedeco.javacpp.tools.InfoMap;
+import org.bytedeco.javacpp.tools.InfoMapper;
 
 @Properties(
     inherit = javacpp.class,
     target = "org.bytedeco.javacpp.chrono",
     global = "org.bytedeco.javacpp.chrono.Chrono"
 )
-public class chrono {
+public class chrono implements InfoMapper {
+    @Override public void map(InfoMap infoMap) {
+        infoMap
+            .put(new Info("std::chrono::high_resolution_clock").pointerTypes("HighResolutionClock"))
+            .put(new Info("std::chrono::steady_clock").pointerTypes("SteadyClock"))
+            .put(new Info("std::chrono::system_clock").pointerTypes("SystemClock"))
+
+            .put(new Info("std::chrono::time_point<std::chrono::high_resolution_clock>").pointerTypes("HighResolutionTime"))
+            .put(new Info("std::chrono::time_point<std::chrono::steady_clock>").pointerTypes("SteadyTime"))
+            .put(new Info("std::chrono::time_point<std::chrono::system_clock>").pointerTypes("SystemTime"))
+
+            .put(new Info("std::chrono::high_resolution_clock::duration").pointerTypes("HighResolutionDuration"))
+            .put(new Info("std::chrono::steady_clock::duration").pointerTypes("SteadyDuration"))
+            .put(new Info("std::chrono::system_clock::duration").pointerTypes("SystemDuration"))
+
+            .put(new Info("std::chrono::hours").pointerTypes("Hours"))
+            .put(new Info("std::chrono::minutes").pointerTypes("Minutes"))
+            .put(new Info("std::chrono::seconds", "std::chrono::duration<long>", "std::chrono::duration<long,std::ratio<1> >", "std::chrono::duration<long,std::ratio<1,1> >").pointerTypes("Seconds"))
+            .put(new Info("std::chrono::milliseconds", "std::chrono::duration<long,std::milli>", "std::chrono::duration<long,std::ratio<1,1000> >").pointerTypes("Milliseconds"))
+            .put(new Info("std::chrono::microseconds", "std::chrono::duration<long,std::micro>", "std::chrono::duration<long,std::ratio<1,1000000> >").pointerTypes("Microseconds"))
+            .put(new Info("std::chrono::nanoseconds", "std::chrono::duration<long,std::nano>", "std::chrono::duration<long,std::ratio<1,1000000000> >").pointerTypes("Nanoseconds"))
+
+            .put(new Info("std::chrono::duration<float>", "std::chrono::duration<float,std::ratio<1> >", "std::chrono::duration<float,std::ratio<1,1> >").pointerTypes("SecondsFloat"))
+            .put(new Info("std::chrono::duration<double>", "std::chrono::duration<double,std::ratio<1> >", "std::chrono::duration<double,std::ratio<1,1> >").pointerTypes("SecondsDouble"))
+        ;
+    }
 }

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -365,6 +365,7 @@ public class Generator {
         out.println("#include <exception>");
         out.println("#include <memory>");
         out.println("#include <new>");
+        out.println("#include <chrono>");
         if (baseLoadSuffix == null || baseLoadSuffix.isEmpty()) {
             out.println();
             out.println("#if defined(NATIVE_ALLOCATOR) && defined(NATIVE_DEALLOCATOR)");

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -3539,13 +3539,13 @@ public class Parser {
         Context ctx = new Context(context);
         Token[] prefixes = {Token.CLASS, Token.INTERFACE, Token.__INTERFACE, Token.STRUCT, Token.UNION};
         for (Token token = tokens.get(); !token.match(Token.EOF); token = tokens.next()) {
-            if (token.match(prefixes)) {
+            if (token.match((Object[]) prefixes)) {
                 foundGroup = true;
                 ctx.inaccessible = token.match(Token.CLASS);
                 break;
             } else if (token.match(Token.FRIEND)) {
                 friend = true;
-                if (!tokens.get(1).match(prefixes)) {
+                if (!tokens.get(1).match((Object[]) prefixes)) {
                     // assume group name follows
                     foundGroup = true;
                     break;

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -3,6 +3,7 @@ module org.bytedeco.javacpp {
     exports org.bytedeco.javacpp;
     exports org.bytedeco.javacpp.annotation;
     exports org.bytedeco.javacpp.chrono;
+    exports org.bytedeco.javacpp.global;
     exports org.bytedeco.javacpp.indexer;
     exports org.bytedeco.javacpp.tools;
     exports org.bytedeco.javacpp.presets;

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -2,6 +2,7 @@ module org.bytedeco.javacpp {
     requires jdk.unsupported;
     exports org.bytedeco.javacpp;
     exports org.bytedeco.javacpp.annotation;
+    exports org.bytedeco.javacpp.chrono;
     exports org.bytedeco.javacpp.indexer;
     exports org.bytedeco.javacpp.tools;
     exports org.bytedeco.javacpp.presets;


### PR DESCRIPTION
Add support for the standard chrono library, sticking to C++11 (not the additions of C++20).

`std::chrono` makes heavy uses of templates.
This PR add mapping for the classical integral durations, and 2 floating point durations.

Concerning the instantiation of function and operator templates (mathematical operations, comparisons...), we have 3 options:
* only map the necessary functions. To add a duration in seconds `s` and a duration in hours `h`, users will have to do:
```Java
  Seconds s2 = new Seconds(s.count() + h.count() * 3600);
```
  or:
```Java
  Seconds s2 = new Seconds(s.count() + new Seconds(h).count());
```
* map all unary operators/functions, and binary operators/functions but for same types. Users will be able to do:
```Java
  Seconds s2 = s.add(new Seconds(h));
```
Or rather:
```Java
  Seconds s2 = Duration.add(s, new Seconds(h));
```
This needs about 7 Java methods per templated function/operator.
* map all combinations, so that users can do:
```Java
  Seconds s2 = s.add(h);
```
or:
```Java
  Seconds s2 = Duration.add(s, h);
```
This needs about 28 Java methods per binary templated function/operator.




  