### PR TITLE
[DO NOT MERGE] Do not avoid copying array content for const ** arrays. Do that for `* const`s.

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -3031,7 +3031,7 @@ public class Generator {
             
             // If const array, then use JNI_ABORT to avoid copying unmodified data back to JVM
             final String releaseArrayFlag;
-            if (cast.contains(" const *") || cast.startsWith("(const ")) {
+            if (cast.contains("* const") || cast.endsWith("const)")) {
                 releaseArrayFlag = "JNI_ABORT";
             } else {
                 releaseArrayFlag = "0";


### PR DESCRIPTION
This fixes https://github.com/bytedeco/javacpp/issues/776

Before this change, we did not copy array contents back to the argument array for "const **" as it is regarded as immutable. But it in fact it mutable. This StackOverflow question describes it well.
https://stackoverflow.com/questions/4949254/const-char-const-versus-const-char

After this change, it will avoid copying if the parameter pointer itself is const.