### PR TITLE
Refined Generator.java to fix a flaky error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Generator` flakiness caused by calls to `Class.getDeclaredMethods()` ([pull #784](https://github.com/bytedeco/javacpp/pull/784))
  * Add minimal mappings for `std::chrono` from C++11 ([pull #766](https://github.com/bytedeco/javacpp/pull/766))
  * Let `Parser` annotate Java constructors with `@Deprecated` when appropriate ([pull #757](https://github.com/bytedeco/javacpp/pull/757))
  * Add to `InfoMap.defaults` more names that are reserved in Java, but not in C++ ([pull #757](https://github.com/bytedeco/javacpp/pull/757))

--- a/src/main/java/org/bytedeco/javacpp/tools/Generator.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Generator.java
@@ -2116,7 +2116,7 @@ public class Generator {
             c = c.getSuperclass();
         }
         boolean[] callbackAllocators = new boolean[methods.length];
-        Method[] functionMethods = functionMethods(cls, callbackAllocators);
+        Method[] functionMethods = functionMethods(cls, methods, callbackAllocators);
         boolean firstCallback = true;
         for (int i = 0; i < methods.length; i++) {
             if (!Loader.checkPlatform(methods[i].getAnnotation(Platform.class), properties)) {
@@ -3636,11 +3636,10 @@ public class Generator {
         return name != null ? name.value()[0] : "JavaCPP_" + mangle(cls.getName());
     }
 
-    static Method[] functionMethods(Class<?> cls, boolean[] callbackAllocators) {
+    static Method[] functionMethods(Class<?> cls, Method[] methods, boolean[] callbackAllocators) {
         if (!FunctionPointer.class.isAssignableFrom(cls)) {
             return null;
         }
-        Method[] methods = cls.getDeclaredMethods();
         Method[] functionMethods = new Method[3];
         for (int i = 0; i < methods.length; i++) {
             String methodName = methods[i].getName();
@@ -4386,7 +4385,7 @@ public class Generator {
         } else if (type.isPrimitive()) {
             prefix = type.getName();
         } else if (FunctionPointer.class.isAssignableFrom(type)) {
-            Method[] functionMethods = functionMethods(type, null);
+            Method[] functionMethods = functionMethods(type, type.getDeclaredMethods(), null);
             String[] prefixSuffix = cppFunctionTypeName(functionMethods);
             if (prefixSuffix != null) {
                 return prefixSuffix;


### PR DESCRIPTION
## Description
This PR fixes a flaky error in `setUpClass()` caused by inconsistent ordering of methods returned by two separate `getDeclaredMethods()` calls, as described in https://github.com/bytedeco/javacpp/pull/727.

The previous solution in https://github.com/bytedeco/javacpp/pull/727 sorted methods by name, which added inefficiency. Instead, this PR merges the two `getDeclaredMethods()` calls into one, ensuring a consistent method order without the need for sorting. (https://github.com/bytedeco/javacpp/pull/727#issuecomment-1826464058)

## Key Changes
Modified the function `static Method[] functionMethods` to accept the methods array as a parameter, avoiding the redundant call to `getDeclaredMethods()` within the function that lead to inconsistency.

## Related Issues
https://github.com/bytedeco/javacpp/pull/727