### PR TITLE
Remove unused compile time imports

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/FunctionPointer.java
+++ b/src/main/java/org/bytedeco/javacpp/FunctionPointer.java
@@ -26,11 +26,10 @@ import org.bytedeco.javacpp.annotation.ByPtr;
 import org.bytedeco.javacpp.annotation.ByRef;
 import org.bytedeco.javacpp.annotation.ByVal;
 import org.bytedeco.javacpp.annotation.ValueSetter;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * All peer classes to function pointers must derive from FunctionPointer.
- * Defining a subclass lets {@link Generator} create a native function type.
+ * Defining a subclass lets {@link org.bytedeco.javacpp.tools.Generator} create a native function type.
  * A C++ function object gets instantiated for each call to {@code allocate()}
  * as well. That function object can be accessed by annotating any method
  * parameter with {@link ByVal} or {@link ByRef}. By default, an actual
@@ -47,7 +46,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * along with {@code native} declarations for {@code allocate()} and {@code call()}.
  * After allocating the object and setting the value, we can be call it from Java.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/Loader.java
+++ b/src/main/java/org/bytedeco/javacpp/Loader.java
@@ -62,7 +62,6 @@ import org.bytedeco.javacpp.annotation.Cast;
 import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Platform;
 import org.bytedeco.javacpp.annotation.Raw;
-import org.bytedeco.javacpp.tools.Builder;
 import org.bytedeco.javacpp.tools.Logger;
 
 /**
@@ -1056,7 +1055,7 @@ public class Loader {
     }
 
     /** Returns {@code System.getProperty("org.bytedeco.javacpp.loadlibraries")}.
-     *  Flag set by the {@link Builder} to tell us not to try to load anything. */
+     *  Flag set by the {@link org.bytedeco.javacpp.tools.Builder} to tell us not to try to load anything. */
     public static boolean isLoadLibraries() {
         String s = System.getProperty("org.bytedeco.javacpp.loadlibraries", "true").toLowerCase();
         s = System.getProperty("org.bytedeco.javacpp.loadLibraries", s).toLowerCase();

--- a/src/main/java/org/bytedeco/javacpp/Pointer.java
+++ b/src/main/java/org/bytedeco/javacpp/Pointer.java
@@ -34,14 +34,13 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Raw;
-import org.bytedeco.javacpp.tools.Generator;
 import org.bytedeco.javacpp.tools.Logger;
 
 /**
  * All peer classes to native types must be descended from Pointer, the topmost class.
  * It can be thought as mapping the native C++ {@code void*}, which can point to any
  * {@code struct}, {@code class}, or {@code union}. All Pointer classes get parsed
- * by {@link Generator} to produce proper wrapping JNI code, but this base class also
+ * by {@link org.bytedeco.javacpp.tools.Generator} to produce proper wrapping JNI code, but this base class also
  * provides functionality to access native array elements as well as utility methods
  * and classes to let users benefit not only from from garbage collection, but also the
  * try-with-resources statement, since it implements the {@link AutoCloseable} interface.

--- a/src/main/java/org/bytedeco/javacpp/annotation/Adapter.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Adapter.java
@@ -6,16 +6,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.Buffer;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Specifies a C++ class to act as an adapter between a target type and one or more adaptee type(s).
  * Instances of the adapter class are short-living and last only for the duration of a JNI call.
  * <p></p>
- * Six such C++ classes are made available by {@link Generator} to bridge a few differences, for instance,
+ * Six such C++ classes are made available by {@link org.bytedeco.javacpp.tools.Generator} to bridge a few differences, for instance,
  * between {@code std::string} and {@link String}, between {@code std::vector}, Java arrays of primitive
- * types, {@link Buffer}, and {@link Pointer}, or between {@code xyz::shared_ptr} and {@link Pointer}:
+ * types, {@link Buffer}, and {@link org.bytedeco.javacpp.Pointer}, or between {@code xyz::shared_ptr} and {@link org.bytedeco.javacpp.Pointer}:
  * <blockquote>
  * <table width="80%">
  *     <thead>
@@ -90,7 +88,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * To reduce further the amount of coding, this annotation can also be used on
  * other annotations, such as with {@link StdString}, {@link StdVector}, and {@link SharedPtr}.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */
@@ -99,7 +97,7 @@ import org.bytedeco.javacpp.tools.Generator;
 public @interface Adapter {
     /** The name of the C++ adapter class. */
     String value();
-    /** The number of arguments that {@link Generator} takes from the method as
+    /** The number of arguments that {@link org.bytedeco.javacpp.tools.Generator} takes from the method as
      *  arguments to the adapter constructor. */
     int argc() default 1;
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/Allocator.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Allocator.java
@@ -5,9 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.FunctionPointer;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * An annotation indicating that a method should behave like an allocator.
@@ -18,21 +15,21 @@ import org.bytedeco.javacpp.tools.Generator;
  * native C++ constructors.
  * <p>
  * In a nutshell, an allocator uses the C++ {@code new} operator along with all
- * the given arguments, and initializes the {@link Pointer#address} as well as
- * the {@link Pointer#deallocator} with {@code NativeDeallocator}, based on the
+ * the given arguments, and initializes the {@link org.bytedeco.javacpp.Pointer#address} as well as
+ * the {@link org.bytedeco.javacpp.Pointer#deallocator} with {@code NativeDeallocator}, based on the
  * {@code delete} operator, if not additionally annotated with {@link NoDeallocator}.
  * <p>
  * Can also be used on classes to set the {@link #max} value for enclosed function pointers.
  *
- * @see Pointer#init(long, long, long, long)
- * @see Generator
+ * @see org.bytedeco.javacpp.Pointer#init(long, long, long, long)
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */
 @Documented @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface Allocator {
-    /** The maximum number of instances that can be allocated in the case of a {@link FunctionPointer} subclass.
-     *  Does not affect the underlying function object or other {@link Pointer} which have no such allocation limits. */
+    /** The maximum number of instances that can be allocated in the case of a {@link org.bytedeco.javacpp.FunctionPointer} subclass.
+     *  Does not affect the underlying function object or other {@link org.bytedeco.javacpp.Pointer} which have no such allocation limits. */
     int max() default 10;
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/ArrayAllocator.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/ArrayAllocator.java
@@ -5,8 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * An annotation indicating that a method should behave like an array allocator.
@@ -15,12 +13,12 @@ import org.bytedeco.javacpp.tools.Generator;
  * changed by annotating the method with the {@link Function} annotation.
  * <p>
  * In a nutshell, an array allocator uses the C++ {@code new[]} operator, and
- * initializes the {@link Pointer#address} as well as the {@link Pointer#deallocator}
+ * initializes the {@link org.bytedeco.javacpp.Pointer#address} as well as the {@link org.bytedeco.javacpp.Pointer#deallocator}
  * with {@code NativeDeallocator}, based on the {@code delete[]} operator, if
  * not additionally annotated with {@link NoDeallocator}.
  *
- * @see Pointer#init(long, long, long, long)
- * @see Generator
+ * @see org.bytedeco.javacpp.Pointer#init(long, long, long, long)
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/AsUtf16.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/AsUtf16.java
@@ -1,14 +1,12 @@
 package org.bytedeco.javacpp.annotation;
 
-import org.bytedeco.javacpp.tools.Generator;
-
 import java.lang.annotation.*;
 
 /**
  * Indicates that {@link java.lang.String} should be mapped to array of UTF-16
  * code units ({@code char16_t*}) instead of byte array ({@code const char*}).
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Alexey Rochev
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/ByPtr.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/ByPtr.java
@@ -5,15 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Indicates that an argument should get passed or returned by pointer. By default,
- * all {@link Pointer} and array arguments get passed by pointer. Since it is
+ * all {@link org.bytedeco.javacpp.Pointer} and array arguments get passed by pointer. Since it is
  * not used for any other purposes at the moment, this annotation has no effect.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/ByPtrPtr.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/ByPtrPtr.java
@@ -5,15 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.PointerPointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Indicates that an argument gets passed or returned by a pointer to a pointer.
- * This is usually used as a shortcut for the more versatile {@link PointerPointer}
+ * This is usually used as a shortcut for the more versatile {@link org.bytedeco.javacpp.PointerPointer}
  * peer class, but where the latter is not needed because the argument is not an array.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/ByPtrRef.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/ByPtrRef.java
@@ -5,13 +5,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Indicates that an argument gets passed or returned by a reference to a pointer.
  * In C++, such a beast looks like {@code *&}, usually to output pointers via parameters.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/ByRef.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/ByRef.java
@@ -5,15 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.FunctionPointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Indicates that an argument gets passed or returned by reference. When used
- * alongside {@link FunctionPointer}, the {@link Generator} passes the underlying
+ * alongside {@link org.bytedeco.javacpp.FunctionPointer}, the {@link org.bytedeco.javacpp.tools.Generator} passes the underlying
  * C++ function object (aka functor) instead of a function pointer.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/ByVal.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/ByVal.java
@@ -5,15 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.FunctionPointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Indicates that an argument gets passed or returned by value. When used
- * alongside {@link FunctionPointer}, the {@link Generator} passes the underlying
+ * alongside {@link org.bytedeco.javacpp.FunctionPointer}, the {@link org.bytedeco.javacpp.tools.Generator} passes the underlying
  * C++ function object (aka functor) instead of a function pointer.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Cast.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Cast.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Indicates a type cast required on the argument to satisfy the native compiler.
@@ -14,12 +13,12 @@ import org.bytedeco.javacpp.tools.Generator;
  * A third "precast" can also be specified, which gets applied before the second one,
    but also on return values passed to adapters.
  * <p>
- * At the moment, {@link Generator} makes use of the simple C-style cast. If one
+ * At the moment, {@link org.bytedeco.javacpp.tools.Generator} makes use of the simple C-style cast. If one
  * requires a different kind of type conversion, such as the {@code dynamic_cast}
  * operator, those can be accessed as if they were functions (with the {@link Name}
  * annotation to specify the type) because they have the same syntax.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Const.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Const.java
@@ -5,8 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.FunctionPointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * A shortcut annotation to {@link Cast} that simply adds {@code const} to the parameter type, function, or class.
@@ -16,10 +14,10 @@ import org.bytedeco.javacpp.tools.Generator;
  * <li>For a function, the first, second, and third ones are used. The first two are applied to the return value/pointer.
  *     The third one determines whether the function is {@code const} or not. For backward compatibility, we keep the third element empty.
  * <li>For a class, only the first one is used, and if it is {@code true}, it means all the functions are {@code const}.
- *     Can also be declared on a {@link FunctionPointer} in the case of {@code const} functions.
+ *     Can also be declared on a {@link org.bytedeco.javacpp.FunctionPointer} in the case of {@code const} functions.
  * </ul></p>
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Convention.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Convention.java
@@ -5,13 +5,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.FunctionPointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
- * Specifies the calling convention of a {@link FunctionPointer}.
+ * Specifies the calling convention of a {@link org.bytedeco.javacpp.FunctionPointer}.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/CriticalRegion.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/CriticalRegion.java
@@ -1,16 +1,14 @@
 package org.bytedeco.javacpp.annotation;
 
-import org.bytedeco.javacpp.tools.Generator;
-
 import java.lang.annotation.*;
 
 /**
- * In some methods, {@link Generator} will generate code to transfer arrays from the
+ * In some methods, {@link org.bytedeco.javacpp.tools.Generator} will generate code to transfer arrays from the
  * JVM to native code using the {@code Get/Release<primitivetype>ArrayElements} methods.
  * However these methods copy the underlying data. With this annotation, the generated
  * code will always call the {@code Get/ReleasePrimitiveArrayCritical} methods instead.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  */
 @Documented @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/bytedeco/javacpp/annotation/Function.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Function.java
@@ -5,11 +5,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Overrides the detection of allocators, getters, and setters. Indicates to the
- * {@link Generator} that we wish the method to call the corresponding C++ function.
+ * {@link org.bytedeco.javacpp.tools.Generator} that we wish the method to call the corresponding C++ function.
  *
  * @see Allocator
  * @see ArrayAllocator
@@ -17,7 +16,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * @see MemberSetter
  * @see ValueSetter
  * @see ValueGetter
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Index.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Index.java
@@ -5,14 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Allows using method arguments to call {@code operator[]} in some circumstances.
  * For example, a call like {@code (*this)[i].foo(str)} could be accomplished with
  * {@code @Index native void foo(int i, String str)}.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/MemberGetter.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/MemberGetter.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * An annotation indicating that a method should behave like a member getter.
@@ -21,7 +20,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * potential work with this annotation. For getters with a return value, all
  * arguments are considered as indices to access a member array.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/MemberSetter.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/MemberSetter.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * An annotation indicating that a method should behave like a member setter.
@@ -21,7 +20,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * the assignment of a member variable could potentially work with this annotation.
  * All but the last argument are considered as indices to access a member array.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Name.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Name.java
@@ -5,18 +5,17 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Names the identifier of a native C++ struct, class, union, function, variable,
- * operator, macro, etc. Without this annotation, {@link Generator} guesses the
+ * operator, macro, etc. Without this annotation, {@link org.bytedeco.javacpp.tools.Generator} guesses the
  * native name based on the name of the Java peer. However, it may sometimes be
  * impossible to use the same name in Java, for example, in the case of overloaded
  * operators or to specify template arguments, while other times we may need to
  * access by name, for example, a callback pointer or function object, from C++.
  * For all those cases, we require this annotation.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Namespace.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Namespace.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Encloses the scope of a Java class inside the scope of the given C++ namespace.
@@ -18,7 +17,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * Further, a namespace annotation with an empty value can be used to indicate
  * that the identifier does not support namespaces (such as macros).
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/NoDeallocator.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/NoDeallocator.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * By default, all allocators attach a deallocator to the peer object on creation.
@@ -18,7 +17,7 @@ import org.bytedeco.javacpp.tools.Generator;
  *
  * @see Allocator
  * @see ArrayAllocator
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/NoException.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/NoException.java
@@ -5,17 +5,16 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
- * By default, {@link Generator} assumes all native functions may throw exceptions.
+ * By default, {@link org.bytedeco.javacpp.tools.Generator} assumes all native functions may throw exceptions.
  * This way, any C++ exception thrown from a function gets caught and translated
  * into a {@link RuntimeException}. However, this adds some overhead and requires
  * additional support from the compiler. Annotating a class or a method with this
  * annotation indicates that none of the enclosed functions can throw exceptions,
  * and need not be included in a {@code try{ ... }} block.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/NoOffset.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/NoOffset.java
@@ -5,19 +5,17 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Loader;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
- * By default, {@link Generator} applies {@code offsetof()} to all member variables.
- * For each value returned {@link Loader#putMemberOffset(String, String, int)}
+ * By default, {@link org.bytedeco.javacpp.tools.Generator} applies {@code offsetof()} to all member variables.
+ * For each value returned {@link org.bytedeco.javacpp.Loader#putMemberOffset(String, String, int)}
  * gets called, allowing to query efficiently those values from Java at a later
- * point by calling {@link Loader#offsetof(Class, String)}. However, this is
+ * point by calling {@link org.bytedeco.javacpp.Loader#offsetof(Class, String)}. However, this is
  * only guaranteed to work on plain old data (POD) {@code struct}. To prevent
  * the C++ compiler from complaining in other cases, we can add this annotation
  * to the peer class declaration.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Opaque.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Opaque.java
@@ -5,16 +5,14 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * This annotation must be used for native types that get declared but not defined.
  * Such types do not work with the {@code sizeof()} operator and their pointers
- * do not support arithmetic, so for peer classes thus annotated, {@link Generator}
- * then also ignores the {@link Pointer#position} value.
+ * do not support arithmetic, so for peer classes thus annotated, {@link org.bytedeco.javacpp.tools.Generator}
+ * then also ignores the {@link org.bytedeco.javacpp.Pointer#position} value.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Optional.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Optional.java
@@ -5,8 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * A shorthand for {@code @Adapter("OptionalAdapter<type>")}.
@@ -14,7 +12,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * to something like {@code boost} instead of the default {@code std}.
  *
  * @see Adapter
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */
@@ -23,6 +21,6 @@ import org.bytedeco.javacpp.tools.Generator;
 @Adapter("OptionalAdapter")
 public @interface Optional {
     /** The template type of {@code OptionalAdapter}. If not specified, it is
-     *  inferred from the value type of the {@link Pointer} or Java array. */
+     *  inferred from the value type of the {@link org.bytedeco.javacpp.Pointer} or Java array. */
     String value() default "";
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/Platform.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Platform.java
@@ -5,16 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Loader;
-import org.bytedeco.javacpp.tools.Builder;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Defines native properties for a top-level enclosing class as well as indicates
  * classes and methods that should be generated or not, for specified platforms.
  * <p>
  * A class or method annotated with only {@link #value()} or {@link #not()}
- * lets {@link Generator} know for which platforms it should generate code
+ * lets {@link org.bytedeco.javacpp.tools.Generator} know for which platforms it should generate code
  * (or not). The strings are matched with {@link String#startsWith(String)}.
  * In particular, {@code @Platform(value="")} matches all platforms, while
  * {@code @Platform(not="")} matches no platforms, providing a way to specify
@@ -22,17 +19,17 @@ import org.bytedeco.javacpp.tools.Generator;
  * regular expressions can also be used with {@code @Platform(pattern="")}.
  * <p>
  * Classes annotated with at least one of the other values define a top-enclosing
- * class as returned by {@link Loader#getEnclosingClass(Class)}. By default, one
- * native library gets created for each such class, but {@link Builder} recognizes
+ * class as returned by {@link org.bytedeco.javacpp.Loader#getEnclosingClass(Class)}. By default, one
+ * native library gets created for each such class, but {@link org.bytedeco.javacpp.tools.Builder} recognizes
  * more than one class with the same {@link #library()} name and produces only one
  * library in that case.
  * <p>
  * Further, with the {@link Properties} annotation, properties can be inherited
  * from other classes, and different properties can be defined for each platform.
  *
- * @see Builder
- * @see Generator
- * @see Loader
+ * @see org.bytedeco.javacpp.tools.Builder
+ * @see org.bytedeco.javacpp.tools.Generator
+ * @see org.bytedeco.javacpp.Loader
  *
  * @author Samuel Audet
  */
@@ -69,7 +66,7 @@ public @interface Platform {
     /** A list of options applied for the native compiler. The options here refer to
      *  property names. The actual command line options of the native compiler are the
      *  values of these properties, which need to be defined elsewhere. On an empty
-     *  array, the {@link Builder} uses the "platform.compiler.default" property. */
+     *  array, the {@link org.bytedeco.javacpp.tools.Builder} uses the "platform.compiler.default" property. */
     String[] compiler()    default {};
     /** A list of library paths passed to the native compiler for use at link time. */
     String[] linkpath()    default {};
@@ -102,8 +99,8 @@ public @interface Platform {
     String[] executablepath() default {};
     /** Executables to bundle at build time and extract at runtime on load, instead of a library. */
     String[] executable()     default {};
-    /** The native JNI library associated with this class that {@link Builder} should
-     *  try to build and {@link Loader} should try to load. If left empty, this value
+    /** The native JNI library associated with this class that {@link org.bytedeco.javacpp.tools.Builder} should
+     *  try to build and {@link org.bytedeco.javacpp.Loader} should try to load. If left empty, this value
      *  defaults to "jni" + the name that {@link Class#getSimpleName()} returns for
      *  {@link Properties#target} or {@link Properties#global} class, or this class, if not given. */
     String   library()     default "";

--- a/src/main/java/org/bytedeco/javacpp/annotation/Properties.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Properties.java
@@ -5,10 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Loader;
-import org.bytedeco.javacpp.tools.Builder;
-import org.bytedeco.javacpp.tools.Generator;
-import org.bytedeco.javacpp.tools.Parser;
 
 /**
  * Makes it possible to define more than one set of properties for each platform.
@@ -18,16 +14,16 @@ import org.bytedeco.javacpp.tools.Parser;
  * and specializing a smaller set of properties for each platform, subsequently.
  * <p>
  * A class with this annotation gets recognized as top-level enclosing class by
- * {@link Loader#getEnclosingClass(Class)}, with the same implications as with
- * the {@link Platform} annotation.
+ * {@link org.bytedeco.javacpp.Loader#getEnclosingClass(Class)}, with the same
+ * implications as with the {@link Platform} annotation.
  * <p>
  * Additionally, it is possible to inherit properties from another class also
  * annotated with this annotation, and specialize further for the current class.
  *
- * @see Builder
- * @see Generator
- * @see Loader
- * @see Parser
+ * @see org.bytedeco.javacpp.tools.Builder
+ * @see org.bytedeco.javacpp.tools.Generator
+ * @see org.bytedeco.javacpp.Loader
+ * @see org.bytedeco.javacpp.tools.Parser
  *
  * @author Samuel Audet
  */
@@ -40,13 +36,13 @@ public @interface Properties {
     String[] names() default {};
     /** A list of properties for different platforms. */
     Platform[] value() default {};
-    /** The target Java source code file of the {@link Parser}, unless {@link #global()} is set,
-        in which case this specifies the target Java package. */
+    /** The target Java source code file of the {@link org.bytedeco.javacpp.tools.Parser}, unless
+        {@link #global()} is set, in which case this specifies the target Java package. */
     String target() default "";
     /** The name of a class where to output any global declarations that are not in classes.
         If left empty, considers the {@link #target()} as a class where to put everything. */
     String global() default "";
-    /** An optional helper class the {@link Parser} should use as base for the global class.
-        Defaults to the class where this annotation was found. */
+    /** An optional helper class the {@link org.bytedeco.javacpp.tools.Parser} should use as base
+        for the global class. Defaults to the class where this annotation was found. */
     String helper() default "";
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/Raw.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Raw.java
@@ -6,17 +6,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.Buffer;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Allows passing and returning Java objects with native functions and raw JNI types.
- * By default, only descendents of {@link Pointer}, direct NIO {@link Buffer},
+ * By default, only descendents of {@link org.bytedeco.javacpp.Pointer}, direct NIO {@link Buffer},
  * {@link String}, primitive types, and their arrays are allowed as arguments to
- * native functions. We can use this annotation to tell the {@link Generator}
+ * native functions. We can use this annotation to tell the {@link org.bytedeco.javacpp.tools.Generator}
  * that we wish to manipulate the actual raw JNI objects in C++.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/SharedPtr.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/SharedPtr.java
@@ -5,8 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * A shorthand for {@code @Adapter("SharedPtrAdapter<type>")}.
@@ -14,7 +12,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * to something like {@code boost} instead of the default {@code std}.
  *
  * @see Adapter
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */
@@ -23,6 +21,6 @@ import org.bytedeco.javacpp.tools.Generator;
 @Adapter("SharedPtrAdapter")
 public @interface SharedPtr {
     /** The template type of {@code SharedPtrAdapter}. If not specified, it is
-     *  inferred from the value type of the {@link Pointer} or Java array. */
+     *  inferred from the value type of the {@link org.bytedeco.javacpp.Pointer} or Java array. */
     String value() default "";
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/StdBasicString.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/StdBasicString.java
@@ -1,7 +1,5 @@
 package org.bytedeco.javacpp.annotation;
 
-import org.bytedeco.javacpp.Pointer;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -14,6 +12,6 @@ import java.lang.annotation.Target;
 @Adapter("BasicStringAdapter")
 public @interface StdBasicString {
     /** The template type of {@code BasicStringAdapter}. If not specified, it is
-     *  inferred from the value type of the {@link Pointer} or Java array. */
+     *  inferred from the value type of the {@link org.bytedeco.javacpp.Pointer} or Java array. */
     String value() default "";
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/StdMove.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/StdMove.java
@@ -5,14 +5,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * A shorthand for {@code @Adapter("MoveAdapter<type>")}.
  *
  * @see Adapter
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */
@@ -21,6 +19,6 @@ import org.bytedeco.javacpp.tools.Generator;
 @Adapter("MoveAdapter")
 public @interface StdMove {
     /** The template type of {@code MoveAdapter}. If not specified, it is
-     *  inferred from the value type of the {@link Pointer} or Java array. */
+     *  inferred from the value type of the {@link org.bytedeco.javacpp.Pointer} or Java array. */
     String value() default "";
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/StdString.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/StdString.java
@@ -5,13 +5,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * A shorthand for {@code @Cast("std::string&") @Adapter("StringAdapter<char>")}.
  *
  * @see Adapter
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/StdVector.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/StdVector.java
@@ -5,14 +5,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * A shorthand for {@code @Adapter("VectorAdapter<type>")}.
  *
  * @see Adapter
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */
@@ -21,6 +19,6 @@ import org.bytedeco.javacpp.tools.Generator;
 @Adapter("VectorAdapter")
 public @interface StdVector {
     /** The template type of {@code VectorAdapter}. If not specified, it is
-     *  inferred from the value type of the {@link Pointer} or Java array. */
+     *  inferred from the value type of the {@link org.bytedeco.javacpp.Pointer} or Java array. */
     String value() default "";
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/StdWString.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/StdWString.java
@@ -5,13 +5,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * A shorthand for {@code @Cast("std::wstring&") @Adapter("StringAdapter<wchar_t>")}.
  *
  * @see Adapter
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/UniquePtr.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/UniquePtr.java
@@ -5,8 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * A shorthand for {@code @Adapter("UniquePtrAdapter<type>")}.
@@ -14,7 +12,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * to something like {@code boost::movelib} instead of the default {@code std}.
  *
  * @see Adapter
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */
@@ -23,6 +21,6 @@ import org.bytedeco.javacpp.tools.Generator;
 @Adapter("UniquePtrAdapter")
 public @interface UniquePtr {
     /** The template type of {@code UniquePtrAdapter}. If not specified, it is
-     *  inferred from the value type of the {@link Pointer} or Java array. */
+     *  inferred from the value type of the {@link org.bytedeco.javacpp.Pointer} or Java array. */
     String value() default "";
 }

--- a/src/main/java/org/bytedeco/javacpp/annotation/ValueGetter.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/ValueGetter.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * An annotation indicating that a method should behave like a value getter.
@@ -22,7 +21,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * potential work with this annotation. For getters with a return value, all
  * arguments are considered as indices to access a value array.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/ValueSetter.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/ValueSetter.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * An annotation indicating that a method should behave like a value setter.
@@ -22,7 +21,7 @@ import org.bytedeco.javacpp.tools.Generator;
  * assignment of a dereferenced pointer could potentially work with this annotation.
  * All but the last argument are considered as indices to access a value array.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/annotation/Virtual.java
+++ b/src/main/java/org/bytedeco/javacpp/annotation/Virtual.java
@@ -5,13 +5,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.bytedeco.javacpp.tools.Generator;
 
 /**
  * Indicates that a method maps to a virtual function in C++. 
  * This allows a user to override that function in Java.
  *
- * @see Generator
+ * @see org.bytedeco.javacpp.tools.Generator
  *
  * @author Samuel Audet
  */

--- a/src/main/java/org/bytedeco/javacpp/presets/chrono.java
+++ b/src/main/java/org/bytedeco/javacpp/presets/chrono.java
@@ -1,6 +1,5 @@
 package org.bytedeco.javacpp.presets;
 
-import org.bytedeco.javacpp.annotation.Platform;
 import org.bytedeco.javacpp.annotation.Properties;
 import org.bytedeco.javacpp.tools.Info;
 import org.bytedeco.javacpp.tools.InfoMap;

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -22,10 +22,6 @@
 
 package org.bytedeco.javacpp.tools;
 
-import org.bytedeco.javacpp.annotation.ByVal;
-import org.bytedeco.javacpp.annotation.Cast;
-import org.bytedeco.javacpp.annotation.Virtual;
-
 /**
  * Holds information useful to the {@link Parser} and associated with C++ identifiers.
  * Info objects are meant to be added by the user to an {@link InfoMap} passed as
@@ -80,7 +76,7 @@ public class Info {
      * variable-like macros for which the type is guessed based on the expression. */
     String[] cppTypes = null;
     /** A list of (usually) primitive Java types to be used to map C++ value types.
-     * By default, {@link #pointerTypes} prefixed with @{@link ByVal} are used. */
+     * By default, {@link #pointerTypes} prefixed with @{@link org.bytedeco.javacpp.annotation.ByVal} are used. */
     String[] valueTypes = null;
     /** A list of (usually) {@link org.bytedeco.javacpp.Pointer} Java subclasses to be used to map C++ pointer types.
      * By default, the names of the C++ types {@link #cppNames} are used. */
@@ -88,7 +84,7 @@ public class Info {
     /** A list of regular expressions (start1, end1, start2, end2, ...) that are matched against lines
      * in header files, where only the ones in between each pair are parsed (or not if {@link #skip} is true). */
     String[] linePatterns = null;
-    /** Annotates Java identifiers with @{@link Cast} containing C++ identifier names {@link #cppNames}. */
+    /** Annotates Java identifiers with @{@link org.bytedeco.javacpp.annotation.Cast} containing C++ identifier names {@link #cppNames}. */
     boolean cast = false;
     /** Indicates expressions of conditional macro groups to parse, or templates to specialize. */
     boolean define = false;
@@ -119,7 +115,7 @@ public class Info {
     /** Whether a static_cast is needed to upcast a pointer to this cppName.
      * This is necessary for polymorphic classes that are virtually inherited from. */
     boolean upcast = false;
-    /** Annotates virtual functions with @{@link Virtual} and adds appropriate constructors. */
+    /** Annotates virtual functions with @{@link org.bytedeco.javacpp.annotation.Virtual} and adds appropriate constructors. */
     boolean virtualize = false;
     /** Allows to override the base class of {@link #pointerTypes}. Defaults to {@link org.bytedeco.javacpp.Pointer}. */
     String base = null;

--- a/src/main/java/org/bytedeco/javacpp/tools/Info.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Info.java
@@ -22,7 +22,6 @@
 
 package org.bytedeco.javacpp.tools;
 
-import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.ByVal;
 import org.bytedeco.javacpp.annotation.Cast;
 import org.bytedeco.javacpp.annotation.Virtual;
@@ -83,7 +82,7 @@ public class Info {
     /** A list of (usually) primitive Java types to be used to map C++ value types.
      * By default, {@link #pointerTypes} prefixed with @{@link ByVal} are used. */
     String[] valueTypes = null;
-    /** A list of (usually) {@link Pointer} Java subclasses to be used to map C++ pointer types.
+    /** A list of (usually) {@link org.bytedeco.javacpp.Pointer} Java subclasses to be used to map C++ pointer types.
      * By default, the names of the C++ types {@link #cppNames} are used. */
     String[] pointerTypes = null;
     /** A list of regular expressions (start1, end1, start2, end2, ...) that are matched against lines
@@ -122,7 +121,7 @@ public class Info {
     boolean upcast = false;
     /** Annotates virtual functions with @{@link Virtual} and adds appropriate constructors. */
     boolean virtualize = false;
-    /** Allows to override the base class of {@link #pointerTypes}. Defaults to {@link Pointer}. */
+    /** Allows to override the base class of {@link #pointerTypes}. Defaults to {@link org.bytedeco.javacpp.Pointer}. */
     String base = null;
     /** Replaces the code associated with the declaration of C++ identifiers, before parsing. */
     String cppText = null;

--- a/src/main/java/org/bytedeco/javacpp/tools/InfoMapper.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/InfoMapper.java
@@ -22,7 +22,6 @@
 
 package org.bytedeco.javacpp.tools;
 
-import org.bytedeco.javacpp.annotation.Properties;
 import org.osgi.annotation.versioning.ConsumerType;
 
 /**
@@ -31,7 +30,7 @@ import org.osgi.annotation.versioning.ConsumerType;
  * will create an instance of the class before calling the {@link #map(InfoMap)}
  * method, to be filled in with {@link Info} objects defined by the user.
  * <p>
- * A class further annotated with {@link Properties#target()} gets detected by
+ * A class further annotated with {@link org.bytedeco.javacpp.annotation.Properties#target()} gets detected by
  * the {@link Builder}, which then delegates it to the {@link Parser}.
  * <p>
  * Note that this interface is intended to be implemented by users of JavaCPP and so is marked

--- a/src/test/java/org/bytedeco/javacpp/ThreadTest.java
+++ b/src/test/java/org/bytedeco/javacpp/ThreadTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.bytedeco.javacpp.annotation.Platform;
 import org.bytedeco.javacpp.annotation.Virtual;


### PR DESCRIPTION
Remove imports that are unused at compile time. This requires fully-qualifying a number of javadoc references.  This allows partial builds and breaks some cyclic dependencies.