### PR TITLE
Prevent Parser from identifying certain operator function as templates (#828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `Parser` failing on `template<... operator<...` functions ([pull #829](https://github.com/bytedeco/javacpp/pull/829))
  * Compile classes with `parameters` bumping minimum requirements to Java SE 8 and Android 7.0 ([issue bytedeco/javacpp-presets#1739](https://github.com/bytedeco/javacpp-presets/issues/1739))
 
 ### February 22, 2026 version 1.5.13

--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -836,7 +836,8 @@ public class Parser {
                 }
                 tokens.next();
                 break;
-            } else if (token.match('<')) {
+            // If it is an operator, it is probably `operator<<`, not start of a template
+            } else if (token.match('<') && !type.operator) {
                 type.arguments = templateArguments(context);
                 type.cppName += "<";
                 String separator = "";


### PR DESCRIPTION
This fixes #828. 

It adds an additional check before handling `<` token, correctly handling call to `operator<<`. 