### PR TITLE
fix: return owned values from generated pop_back

### DIFF
--- a/src/main/java/org/bytedeco/javacpp/tools/Parser.java
+++ b/src/main/java/org/bytedeco/javacpp/tools/Parser.java
@@ -441,6 +441,9 @@ public class Parser {
                                       +  "    public " + removeAnnotations(valueType.javaName) + " back() { return get(size() - 1); }\n";
                         }
                         decl.text += "    @Index" + indexFunction + " public native " + valueType.annotations + valueType.javaName + " get(" + params + ");\n";
+                        if (dim == 1 && indexType.javaName.equals("long") && !constant) {
+                            decl.text += "    @Name(\"operator[]\") public native @ByVal " + removeAnnotations(valueType.javaName) + " getValue(long i);\n";
+                        }
                         if (!constant) {
                             decl.text += "    public native " + containerType.javaName + " put(" + params + separator + removeAnnotations(valueType.javaName) + " value);\n";
                         }
@@ -586,7 +589,7 @@ public class Parser {
                             if (first) {
                                 decl.text += "    public " + javaName + " pop_back() {\n"
                                           +  "        long size = size();\n"
-                                          +  "        " + javaName + " value = get(size - 1);\n"
+                                          +  "        " + javaName + " value = getValue(size - 1);\n"
                                           +  "        resize(size - 1);\n"
                                           +  "        return value;\n"
                                           +  "    }\n";


### PR DESCRIPTION
Fixes the dangling-reference path reported in #830.

The generated `pop_back()` implementation now reads the final element through a separate `@ByVal` `operator[]` binding before resizing the container. That makes the returned JavaCPP wrapper own a copy of the value instead of aliasing the element that `resize()` destroys. The existing `get()` binding remains by-reference for normal indexed access.

I kept this scoped to resizable, long-indexed containers such as `std::vector` and `std::deque`, which are the containers that currently receive the generated `pop_back()` helper.

Validation:
- `git diff --check`
- Full Maven tests were not available because this environment has no Maven installation.

Related: #830